### PR TITLE
Fix publisher flush behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .vscode/
 *.svg
+*.log

--- a/msg-socket/src/pub/driver.rs
+++ b/msg-socket/src/pub/driver.rs
@@ -63,6 +63,7 @@ impl<T: ServerTransport> Future for PubDriver<T> {
                             pending_egress: None,
                             conn: framed,
                             topic_filter: PrefixTrie::new(),
+                            should_flush: false,
                             flush_interval: this.options.flush_interval.map(tokio::time::interval),
                         };
 
@@ -134,6 +135,7 @@ impl<T: ServerTransport> Future for PubDriver<T> {
                             pending_egress: None,
                             conn: Framed::new(stream, pubsub::Codec::new()),
                             topic_filter: PrefixTrie::new(),
+                            should_flush: false,
                             flush_interval: this.options.flush_interval.map(tokio::time::interval),
                         };
 

--- a/msg-socket/src/pub/driver.rs
+++ b/msg-socket/src/pub/driver.rs
@@ -53,7 +53,8 @@ impl<T: ServerTransport> Future for PubDriver<T> {
                         // this.state.stats.increment_active_clients();
 
                         // Default backpressury boundary of 8192 bytes, should we add config option?
-                        let framed = Framed::new(auth.stream, pubsub::Codec::new());
+                        let mut framed = Framed::new(auth.stream, pubsub::Codec::new());
+                        framed.set_backpressure_boundary(this.options.backpressure_boundary);
 
                         let session = SubscriberSession {
                             seq: 0,

--- a/msg-socket/src/pub/driver.rs
+++ b/msg-socket/src/pub/driver.rs
@@ -50,10 +50,13 @@ impl<T: ServerTransport> Future for PubDriver<T> {
                     Ok(auth) => {
                         // Run custom authenticator
                         debug!("Authentication passed for {:?} ({})", auth.id, auth.addr);
-                        // this.state.stats.increment_active_clients();
 
-                        // Default backpressury boundary of 8192 bytes, should we add config option?
-                        let mut framed = Framed::new(auth.stream, pubsub::Codec::new());
+                        let mut framed = Framed::with_capacity(
+                            auth.stream,
+                            pubsub::Codec::new(),
+                            this.options.backpressure_boundary,
+                        );
+
                         framed.set_backpressure_boundary(this.options.backpressure_boundary);
 
                         let session = SubscriberSession {
@@ -127,14 +130,21 @@ impl<T: ServerTransport> Future for PubDriver<T> {
                             })
                         });
                     } else {
-                        // this.state.stats.increment_active_clients();
+                        let mut framed = Framed::with_capacity(
+                            stream,
+                            pubsub::Codec::new(),
+                            this.options.backpressure_boundary,
+                        );
+
+                        framed.set_backpressure_boundary(this.options.backpressure_boundary);
+
                         let session = SubscriberSession {
                             seq: 0,
                             session_id: this.id_counter,
                             from_socket_bcast: this.from_socket_bcast.resubscribe().into(),
                             state: Arc::clone(&this.state),
                             pending_egress: None,
-                            conn: Framed::new(stream, pubsub::Codec::new()),
+                            conn: framed,
                             topic_filter: PrefixTrie::new(),
                             should_flush: false,
                             flush_interval: this.options.flush_interval.map(tokio::time::interval),

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -37,6 +37,9 @@ pub struct PubOptions {
     /// The interval at which each session should be flushed. If this is `None`,
     /// the session will be flushed on every publish, which can add a lot of overhead.
     pub flush_interval: Option<std::time::Duration>,
+    /// The maximum number of bytes that can be buffered in the session before being flushed.
+    /// This internally sets [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
+    pub backpressure_boundary: usize,
 }
 
 impl Default for PubOptions {
@@ -45,6 +48,7 @@ impl Default for PubOptions {
             max_connections: None,
             session_buffer_size: 1024,
             flush_interval: Some(std::time::Duration::from_micros(50)),
+            backpressure_boundary: 8192,
         }
     }
 }

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -44,7 +44,7 @@ impl Default for PubOptions {
         Self {
             max_connections: None,
             session_buffer_size: 1024,
-            flush_interval: Some(std::time::Duration::from_micros(100)),
+            flush_interval: Some(std::time::Duration::from_micros(50)),
         }
     }
 }

--- a/msg-socket/src/pub/session.rs
+++ b/msg-socket/src/pub/session.rs
@@ -133,6 +133,7 @@ fn msg_to_control(msg: &pubsub::Message) -> ControlMsg {
 impl<Io: AsyncRead + AsyncWrite + Unpin> Future for SubscriberSession<Io> {
     type Output = ();
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 

--- a/msg/benches/pubsub.rs
+++ b/msg/benches/pubsub.rs
@@ -30,6 +30,7 @@ mod pubsub {
 
     use super::*;
 
+    /// Last run: 60.01 ms, 853.1 MB/s, 1.666 Mitem/s
     #[divan::bench()]
     fn pubsub_single_thread_tcp(bencher: divan::Bencher) {
         // create a current-threaded tokio runtime
@@ -42,6 +43,8 @@ mod pubsub {
         pubsub_with_runtime(bencher, rt);
     }
 
+    /// Last run:
+    /// Median: 42.83ms, 1.195 GB/s, 2.334 Mitem/s
     #[divan::bench]
     fn pubsub_multi_thread_tcp(bencher: divan::Bencher) {
         // create a multi-threaded tokio runtime
@@ -54,6 +57,8 @@ mod pubsub {
         pubsub_with_runtime(bencher, rt);
     }
 
+    /// Last run:
+    /// Median: 49.86 ms, 1.026 GB/s, 2.005 Mitem/s
     #[divan::bench]
     fn pubsub_2_subscribers(bencher: divan::Bencher) {
         // create a multi-threaded tokio runtime
@@ -67,8 +72,8 @@ mod pubsub {
             Tcp::new(),
             PubOptions {
                 session_buffer_size: N_REQS,
-                flush_interval: Some(Duration::from_micros(50)),
-                backpressure_boundary: 64 * 1024,
+                flush_interval: Some(Duration::from_micros(100)),
+                backpressure_boundary: 1024 * 64,
                 ..Default::default()
             },
         );
@@ -174,8 +179,8 @@ mod pubsub {
         let mut pub_socket = PubSocket::with_options(
             Tcp::new(),
             PubOptions {
-                flush_interval: Some(Duration::from_micros(50)),
-                backpressure_boundary: 512,
+                flush_interval: Some(Duration::from_micros(100)),
+                backpressure_boundary: 1024 * 64,
                 session_buffer_size: N_REQS,
                 ..Default::default()
             },

--- a/msg/benches/pubsub.rs
+++ b/msg/benches/pubsub.rs
@@ -64,7 +64,7 @@ mod pubsub {
             Tcp::new(),
             PubOptions {
                 session_buffer_size: N_REQS,
-                flush_interval: Some(Duration::from_micros(200)),
+                flush_interval: Some(Duration::from_micros(50)),
                 ..Default::default()
             },
         );
@@ -170,6 +170,7 @@ mod pubsub {
         let mut pub_socket = PubSocket::with_options(
             Tcp::new(),
             PubOptions {
+                flush_interval: Some(Duration::from_micros(20)),
                 session_buffer_size: N_REQS,
                 ..Default::default()
             },

--- a/msg/benches/pubsub.rs
+++ b/msg/benches/pubsub.rs
@@ -21,7 +21,7 @@ fn main() {
     divan::main();
 }
 
-#[divan::bench_group(sample_count = 16)]
+#[divan::bench_group(sample_count = 20)]
 mod pubsub {
     use std::time::Duration;
 
@@ -55,6 +55,7 @@ mod pubsub {
     fn pubsub_2_subscribers(bencher: divan::Bencher) {
         // create a multi-threaded tokio runtime
         let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(4)
             .enable_all()
             .build()
             .unwrap();
@@ -63,7 +64,7 @@ mod pubsub {
             Tcp::new(),
             PubOptions {
                 session_buffer_size: N_REQS,
-                flush_interval: Some(Duration::from_micros(100)),
+                flush_interval: Some(Duration::from_micros(200)),
                 ..Default::default()
             },
         );

--- a/msg/benches/reqrep.rs
+++ b/msg/benches/reqrep.rs
@@ -30,6 +30,7 @@ mod reqrep {
 
     use super::*;
 
+    /// Last run: 314 ms, 81.51 MB/s, 159.2 Kitem/s
     #[divan::bench()]
     fn reqrep_single_thread_tcp(bencher: divan::Bencher) {
         // create a multi-threaded tokio runtime
@@ -41,6 +42,7 @@ mod reqrep {
         reqrep_with_runtime(bencher, rt);
     }
 
+    /// Last run: 249.6 ms, 102.5 MB/s, 200.2 Kitem/s
     #[divan::bench()]
     fn reqrep_multi_thread_tcp(bencher: divan::Bencher) {
         // create a multi-threaded tokio runtime
@@ -52,6 +54,7 @@ mod reqrep {
         reqrep_with_runtime(bencher, rt);
     }
 
+    /// Last run: 475.2 ms, 53.86 MB/s, 105.2 Kitem/s
     #[divan::bench]
     fn reqrep_2_request(bencher: divan::Bencher) {
         let rt = tokio::runtime::Builder::new_multi_thread()

--- a/msg/examples/pubsub.rs
+++ b/msg/examples/pubsub.rs
@@ -16,6 +16,7 @@ async fn main() {
         PubOptions {
             session_buffer_size: 1024,
             flush_interval: Some(Duration::from_micros(100)),
+            backpressure_boundary: 8192,
             max_connections: None,
         },
     );

--- a/msg/examples/pubsub_auth.rs
+++ b/msg/examples/pubsub_auth.rs
@@ -32,6 +32,7 @@ async fn main() {
         PubOptions {
             session_buffer_size: 1024,
             flush_interval: Some(Duration::from_micros(100)),
+            backpressure_boundary: 8192,
             max_connections: None,
         },
     )


### PR DESCRIPTION
Previously, the flush interval would wake up the session task every time it expired, regardless of wether there was any need for flushing or not. This PR fixes that by adding some resets to the interval so it doesn't wake up the task as frequently.
