### PR TITLE
Add latency stats to PUBSUB sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
+ "msg-common",
  "msg-transport",
  "msg-wire",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "msg-common"
+version = "0.1.0-alpha"
+
+[[package]]
 name = "msg-socket"
 version = "0.1.0-alpha"
 dependencies = [
@@ -436,6 +440,7 @@ name = "msg-wire"
 version = "0.1.0-alpha"
 dependencies = [
  "bytes",
+ "msg-common",
  "thiserror",
  "tokio-util",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["msg", "msg-socket", "msg-wire", "msg-transport"]
+members = ["msg", "msg-socket", "msg-wire", "msg-transport", "msg-common"]
 
 [workspace.package]
 version = "0.1.0-alpha"
@@ -15,6 +15,7 @@ repository = "https://github.com/chainbound/msg-rs"
 msg-wire = { path = "./msg-wire" }
 msg-socket = { path = "./msg-socket" }
 msg-transport = { path = "./msg-transport" }
+msg-common = { path = "./msg-common" }
 
 # async
 async-trait = "0.1"

--- a/msg-common/Cargo.toml
+++ b/msg-common/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "msg-common"
+description = "Common functions and types for the msg crates"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/msg-common/src/lib.rs
+++ b/msg-common/src/lib.rs
@@ -1,0 +1,9 @@
+use std::time::SystemTime;
+
+/// Returns the current UNIX timestamp in microseconds.
+pub fn unix_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}

--- a/msg-socket/Cargo.toml
+++ b/msg-socket/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 # msg
 msg-wire.workspace = true
 msg-transport.workspace = true
+msg-common.workspace = true
 
 bytes.workspace = true
 futures.workspace = true

--- a/msg-socket/src/pub/driver.rs
+++ b/msg-socket/src/pub/driver.rs
@@ -24,16 +24,10 @@ pub(crate) struct PubDriver<T: ServerTransport> {
     pub(super) options: Arc<PubOptions>,
     /// The publisher socket state, shared with the socket front-end.
     pub(crate) state: Arc<SocketState>,
-    /// Receiver from the socket front-end.
-    // pub(super) from_socket: mpsc::Receiver<Command>,
     /// Optional connection authenticator.
     pub(super) auth: Option<Arc<dyn Authenticator>>,
     /// A joinset of authentication tasks.
     pub(super) auth_tasks: JoinSet<Result<AuthResult<T::Io>, PubError>>,
-    /// Stream map of session receivers, keyed by session ID. This is used to listen to
-    /// requests from the session like subscribe, unsubscribe, and to be notified when the
-    /// session is closed (`StreamNotifyClose`).
-    // pub(super) from_sessions: StreamMap<u32, StreamNotifyClose<ReceiverStream<SessionRequest>>>,
     /// The receiver end of the message broadcast channel. The sender half is stored by [`PubSocket`](super::PubSocket).
     pub(super) from_socket_bcast: broadcast::Receiver<PubMessage>,
 }

--- a/msg-socket/src/pub/driver.rs
+++ b/msg-socket/src/pub/driver.rs
@@ -45,12 +45,7 @@ impl<T: ServerTransport> Future for PubDriver<T> {
                         // Run custom authenticator
                         debug!("Authentication passed for {:?} ({})", auth.id, auth.addr);
 
-                        let mut framed = Framed::with_capacity(
-                            auth.stream,
-                            pubsub::Codec::new(),
-                            this.options.backpressure_boundary,
-                        );
-
+                        let mut framed = Framed::new(auth.stream, pubsub::Codec::new());
                         framed.set_backpressure_boundary(this.options.backpressure_boundary);
 
                         let session = SubscriberSession {
@@ -124,12 +119,7 @@ impl<T: ServerTransport> Future for PubDriver<T> {
                             })
                         });
                     } else {
-                        let mut framed = Framed::with_capacity(
-                            stream,
-                            pubsub::Codec::new(),
-                            this.options.backpressure_boundary,
-                        );
-
+                        let mut framed = Framed::new(stream, pubsub::Codec::new());
                         framed.set_backpressure_boundary(this.options.backpressure_boundary);
 
                         let session = SubscriberSession {

--- a/msg-socket/src/pub/socket.rs
+++ b/msg-socket/src/pub/socket.rs
@@ -32,6 +32,12 @@ impl<T: ServerTransport> PubSocket<T> {
 
     /// Creates a new publisher socket with the given transport and options.
     pub fn with_options(transport: T, options: PubOptions) -> Self {
+        assert_eq!(
+            options.backpressure_boundary % 2,
+            0,
+            "backpressure_boundary must be a multiple of 2"
+        );
+
         Self {
             transport: Some(transport),
             local_addr: None,

--- a/msg-socket/src/sub/driver.rs
+++ b/msg-socket/src/sub/driver.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use futures::{Future, Stream, StreamExt};
+use msg_common::unix_micros;
 use std::collections::{HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -12,8 +13,11 @@ use tokio_stream::StreamMap;
 use tokio_util::codec::Framed;
 use tracing::{debug, error};
 
-use super::stream::TopicMessage;
-use super::{stream::PublisherStream, Command, PubMessage, SubOptions};
+use super::stats::SessionStats;
+use super::{
+    stream::{PublisherStream, TopicMessage},
+    Command, PubMessage, SocketState, SubOptions,
+};
 use msg_transport::ClientTransport;
 use msg_wire::pubsub;
 
@@ -34,6 +38,8 @@ pub(crate) struct SubDriver<T: ClientTransport> {
     pub(super) subscribed_topics: HashSet<String>,
     /// All active publisher sessions for this subscriber socket.
     pub(super) publishers: StreamMap<SocketAddr, PublisherSession<T::Io>>,
+    /// Socket state. This is shared with the backend task.
+    pub(super) state: Arc<SocketState>,
 }
 
 impl<T> Future for SubDriver<T>
@@ -125,6 +131,7 @@ where
             Command::Disconnect { endpoint } => {
                 if self.publishers.remove(&endpoint).is_some() {
                     debug!(endpoint = %endpoint, "Disconnected from publisher");
+                    self.state.stats.remove(&endpoint);
                 } else {
                     debug!(endpoint = %endpoint, "Not connected to publisher");
                 };
@@ -147,14 +154,20 @@ where
     fn on_connection(&mut self, addr: SocketAddr, io: T::Io) {
         // This should spawn a new task tied to this connection, and
         debug!("Connection to {} established, spawning session", addr);
-        let framed = Framed::new(io, pubsub::Codec::new());
+
+        let mut framed = Framed::new(io, pubsub::Codec::new());
+        framed.set_backpressure_boundary(self.options.read_buffer_size);
+
         let mut publisher_session = PublisherSession::new(addr, PublisherStream::new(framed));
+        // Get the shared session stats.
+        let session_stats = publisher_session.stats();
 
         for topic in self.subscribed_topics.iter() {
             publisher_session.subscribe(topic.clone());
         }
 
         self.publishers.insert(addr, publisher_session);
+        self.state.stats.insert(addr, session_stats);
     }
 }
 
@@ -167,6 +180,8 @@ pub(super) struct PublisherSession<Io> {
     egress: VecDeque<pubsub::Message>,
     /// The inner stream
     stream: PublisherStream<Io>,
+    /// The session stats
+    stats: Arc<SessionStats>,
 }
 
 impl<Io: AsyncRead + AsyncWrite + Send + Unpin> PublisherSession<Io> {
@@ -175,7 +190,13 @@ impl<Io: AsyncRead + AsyncWrite + Send + Unpin> PublisherSession<Io> {
             addr,
             stream,
             egress: VecDeque::with_capacity(4),
+            stats: Arc::new(SessionStats::default()),
         }
+    }
+
+    /// Returns a reference to the session stats.
+    fn stats(&self) -> Arc<SessionStats> {
+        Arc::clone(&self.stats)
     }
 
     /// Queues a subscribe message for this publisher.
@@ -204,6 +225,14 @@ impl<Io: AsyncRead + AsyncWrite + Unpin> Stream for PublisherSession<Io> {
         loop {
             match this.stream.poll_next_unpin(cx) {
                 Poll::Ready(Some(result)) => {
+                    // Update session stats
+                    if let Ok(ref msg) = result {
+                        let now = unix_micros();
+
+                        this.stats.increment_rx(msg.payload.len());
+                        this.stats.update_latency(now - msg.timestamp);
+                    }
+
                     return Poll::Ready(Some(result));
                 }
                 Poll::Ready(None) => {

--- a/msg-socket/src/sub/driver.rs
+++ b/msg-socket/src/sub/driver.rs
@@ -155,8 +155,7 @@ where
         // This should spawn a new task tied to this connection, and
         debug!("Connection to {} established, spawning session", addr);
 
-        let mut framed = Framed::new(io, pubsub::Codec::new());
-        framed.set_backpressure_boundary(self.options.read_buffer_size);
+        let framed = Framed::with_capacity(io, pubsub::Codec::new(), self.options.read_buffer_size);
 
         let mut publisher_session = PublisherSession::new(addr, PublisherStream::new(framed));
         // Get the shared session stats.

--- a/msg-socket/src/sub/stats.rs
+++ b/msg-socket/src/sub/stats.rs
@@ -1,0 +1,86 @@
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use parking_lot::RwLock;
+
+/// Statistics for a reply socket. These are shared between the driver task
+/// and the socket.
+#[derive(Debug, Default)]
+pub struct SocketStats {
+    /// Individual session stats for each publisher
+    session_stats: RwLock<HashMap<SocketAddr, Arc<SessionStats>>>,
+}
+
+impl SocketStats {
+    #[inline]
+    pub(crate) fn insert(&self, addr: SocketAddr, stats: Arc<SessionStats>) {
+        self.session_stats.write().insert(addr, stats);
+    }
+
+    #[inline]
+    pub(crate) fn remove(&self, addr: &SocketAddr) {
+        self.session_stats.write().remove(addr);
+    }
+
+    #[inline]
+    pub fn bytes_rx(&self, session_addr: &SocketAddr) -> Option<usize> {
+        self.session_stats
+            .read()
+            .get(session_addr)
+            .map(|stats| stats.bytes_rx())
+    }
+
+    /// Returns the average latency in microseconds for the given session.
+    #[inline]
+    pub fn avg_latency(&self, session_addr: &SocketAddr) -> Option<u64> {
+        self.session_stats
+            .read()
+            .get(session_addr)
+            .map(|stats| stats.avg_latency())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SessionStats {
+    /// Total bytes received
+    bytes_rx: AtomicUsize,
+    /// The cumulative average latency
+    latency: AtomicU64,
+    /// Index used to calculate CA
+    latency_idx: AtomicU64,
+}
+
+impl SessionStats {
+    #[inline]
+    pub(crate) fn increment_rx(&self, bytes: usize) {
+        self.bytes_rx.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    #[inline]
+    /// Atomically updates the RTT according to the CA formula:
+    /// CA = (rtt + n * prev_ca) / (n + 1)
+    pub(crate) fn update_latency(&self, latency_us: u64) {
+        // Wraps around on overflow, which is what we need
+        let idx = self.latency_idx.fetch_add(1, Ordering::Relaxed);
+        let prev = self.latency.load(Ordering::Relaxed);
+
+        let new = (latency_us + idx * prev) / (idx + 1);
+        self.latency.store(new, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn bytes_rx(&self) -> usize {
+        self.bytes_rx.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn avg_latency(&self) -> u64 {
+        self.latency.load(Ordering::Relaxed)
+    }
+}

--- a/msg-wire/Cargo.toml
+++ b/msg-wire/Cargo.toml
@@ -11,6 +11,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+msg-common.workspace = true
+
 bytes.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true

--- a/msg-wire/src/pubsub.rs
+++ b/msg-wire/src/pubsub.rs
@@ -72,6 +72,11 @@ impl Message {
     }
 
     #[inline]
+    pub fn timestamp(&self) -> u64 {
+        self.header.timestamp
+    }
+
+    #[inline]
     pub fn size(&self) -> usize {
         self.header.len() + self.payload_size() as usize
     }

--- a/msg/benches/pubsub.rs
+++ b/msg/benches/pubsub.rs
@@ -198,9 +198,8 @@ mod pubsub {
         rt.block_on(async {
             pub_socket.bind("127.0.0.1:0").await.unwrap();
 
-            sub.connect(&pub_socket.local_addr().unwrap().to_string())
-                .await
-                .unwrap();
+            let addr = pub_socket.local_addr().unwrap();
+            sub.connect(&addr.to_string()).await.unwrap();
 
             sub.subscribe("HELLO".to_string()).await.unwrap();
 
@@ -234,6 +233,7 @@ mod pubsub {
                     .instrument(tracing::info_span!("publisher"));
 
                     let recv = async {
+                        tokio::time::sleep(Duration::from_micros(5)).await;
                         let mut rx = 0;
                         while let Some(_msg) = sub.next().await {
                             rx += 1;

--- a/msg/examples/durable.rs
+++ b/msg/examples/durable.rs
@@ -19,7 +19,7 @@ impl Authenticator for Auth {
 async fn start_rep() {
     // Initialize the reply socket (server side) with a transport
     // and an authenticator.
-    let mut rep = RepSocket::new(Tcp::new()).with_auth(Auth::default());
+    let mut rep = RepSocket::new(Tcp::new()).with_auth(Auth);
     rep.bind("0.0.0.0:4444").await.unwrap();
 
     // Receive the request and respond with "world"

--- a/msg/examples/pubsub.rs
+++ b/msg/examples/pubsub.rs
@@ -14,9 +14,9 @@ async fn main() {
     let mut pub_socket = PubSocket::with_options(
         Tcp::new(),
         PubOptions {
+            backpressure_boundary: 8192,
             session_buffer_size: 1024,
             flush_interval: Some(Duration::from_micros(100)),
-            backpressure_boundary: 8192,
             max_connections: None,
         },
     );

--- a/msg/examples/pubsub_auth.rs
+++ b/msg/examples/pubsub_auth.rs
@@ -30,14 +30,14 @@ async fn main() {
     let mut pub_socket = PubSocket::with_options(
         Tcp::new(),
         PubOptions {
+            backpressure_boundary: 8192,
             session_buffer_size: 1024,
             flush_interval: Some(Duration::from_micros(100)),
-            backpressure_boundary: 8192,
             max_connections: None,
         },
     )
     // Enable the authenticator
-    .with_auth(Auth::default());
+    .with_auth(Auth);
 
     // Configure the subscribers with options
     let mut sub1 = SubSocket::with_options(

--- a/msg/examples/reqrep_auth.rs
+++ b/msg/examples/reqrep_auth.rs
@@ -18,7 +18,7 @@ impl Authenticator for Auth {
 async fn main() {
     // Initialize the reply socket (server side) with a transport
     // and an authenticator.
-    let mut rep = RepSocket::new(Tcp::new()).with_auth(Auth::default());
+    let mut rep = RepSocket::new(Tcp::new()).with_auth(Auth);
     rep.bind("0.0.0.0:4444").await.unwrap();
 
     // Initialize the request socket (client side) with a transport


### PR DESCRIPTION
This PR adds timestamp & latency stats to the PUBSUB sockets.

The `pubsub::Message` header now has a u64 UNIX timestamp in microseconds. The publisher sets this for every new message, and the subscriber updates its CA for every new message.
