### PR TITLE
Limit outgoing requests

### DIFF
--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -51,7 +51,7 @@ pub struct ReqOptions {
     pub backoff_duration: std::time::Duration,
     pub retry_attempts: Option<usize>,
     pub set_nodelay: bool,
-    pub max_active_requests: usize,
+    pub max_pending_requests: usize,
 }
 
 impl ReqOptions {
@@ -71,7 +71,7 @@ impl Default for ReqOptions {
             backoff_duration: Duration::from_millis(200),
             retry_attempts: None,
             set_nodelay: true,
-            max_active_requests: 100,
+            max_pending_requests: 100,
         }
     }
 }

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -31,6 +31,9 @@ pub enum ReqError {
     InvalidEndpoint(String),
     #[error("Request timed out")]
     Timeout,
+    #[error("Too many requests")]
+    TooManyRequests,
+
 }
 
 pub enum Command {

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -27,6 +27,8 @@ pub enum ReqError {
     SocketClosed,
     #[error("Transport error: {0:?}")]
     Transport(#[from] Box<dyn std::error::Error + Send + Sync>),
+    #[error("Invalid endpoint: {0}")]
+    InvalidEndpoint(String),
     #[error("Request timed out")]
     Timeout,
 }
@@ -46,6 +48,7 @@ pub struct ReqOptions {
     pub backoff_duration: std::time::Duration,
     pub retry_attempts: Option<usize>,
     pub set_nodelay: bool,
+    pub max_active_requests: usize,
 }
 
 impl ReqOptions {
@@ -65,6 +68,7 @@ impl Default for ReqOptions {
             backoff_duration: Duration::from_millis(200),
             retry_attempts: None,
             set_nodelay: true,
+            max_active_requests: 100,
         }
     }
 }

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -10,6 +10,7 @@ use tokio_util::codec::Framed;
 use crate::{req::stats::SocketStats, req::SocketState};
 
 use super::{Command, ReqDriver, ReqError, ReqOptions, DEFAULT_BUFFER_SIZE};
+use tokio::sync::Semaphore;
 
 #[derive(Debug, Clone)]
 pub struct ReqSocket<T: ClientTransport> {
@@ -21,6 +22,8 @@ pub struct ReqSocket<T: ClientTransport> {
     options: Arc<ReqOptions>,
     /// Socket state. This is shared with the backend task.
     state: Arc<SocketState>,
+    /// Semaphore to limit the amount of active outgoing requests.
+    semaphore: Arc<Semaphore>,
 }
 
 impl<T: ClientTransport> ReqSocket<T> {
@@ -32,8 +35,9 @@ impl<T: ClientTransport> ReqSocket<T> {
         Self {
             to_driver: None,
             transport,
-            options: Arc::new(options),
+            options: Arc::new(options.clone()),
             state: Arc::new(SocketState::default()),
+            semaphore: Arc::new(Semaphore::new(options.max_active_requests)),
         }
     }
 
@@ -42,6 +46,7 @@ impl<T: ClientTransport> ReqSocket<T> {
     }
 
     pub async fn request(&self, message: Bytes) -> Result<Bytes, ReqError> {
+        let _permit = self.semaphore.acquire().await;
         let (response_tx, response_rx) = oneshot::channel();
 
         self.to_driver
@@ -62,8 +67,7 @@ impl<T: ClientTransport> ReqSocket<T> {
         // Initialize communication channels
         let (to_driver, from_socket) = mpsc::channel(DEFAULT_BUFFER_SIZE);
 
-        // TODO: return error
-        let endpoint = endpoint.parse().unwrap();
+        let endpoint = endpoint.parse().map_err(|_| ReqError::InvalidEndpoint(endpoint.to_string()))?;
 
         tracing::debug!("Connected to {}", endpoint);
 
@@ -74,19 +78,20 @@ impl<T: ClientTransport> ReqSocket<T> {
             .map_err(|e| ReqError::Transport(Box::new(e)))?;
 
         // Create the socket backend
+        let mut pending_requests = FxHashMap::default();
+        pending_requests.reserve(self.options.max_active_requests);
         let driver = ReqDriver {
             options: Arc::clone(&self.options),
             id_counter: 0,
             from_socket,
             conn: Framed::new(stream, reqrep::Codec::new()),
-            egress_queue: VecDeque::new(),
-            // TODO: we should limit the amount of active outgoing requests, and that should be the capacity.
-            // If we do this, we'll never have to re-allocate.
-            pending_requests: FxHashMap::default(),
+            egress_queue: VecDeque::with_capacity(self.options.max_active_requests),
+            pending_requests,
             socket_state: Arc::clone(&self.state),
             timeout_check_interval: tokio::time::interval(Duration::from_millis(
                 self.options.timeout.as_millis() as u64 / 10,
             )),
+            semaphore: Arc::clone(&self.semaphore),
         };
 
         // Spawn the backend task
@@ -151,6 +156,7 @@ mod tests {
                 backoff_duration: Duration::from_secs(1),
                 retry_attempts: Some(3),
                 set_nodelay: true,
+                max_active_requests: 100,
             },
         );
 
@@ -188,6 +194,7 @@ mod tests {
                 backoff_duration: Duration::from_secs(0),
                 retry_attempts: None,
                 set_nodelay: true,
+                max_active_requests: 100,
             },
         );
 
@@ -207,5 +214,47 @@ mod tests {
             "Request succeeded when it should have timed out: {:?}",
             response.ok()
         );
+    }
+
+    #[tokio::test]
+    async fn test_max_active_requests_limit() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let addr = spawn_listener(Duration::from_secs(0)).await;
+
+        let max_active_requests = 10;
+        let mut socket = ReqSocket::with_options(
+            Tcp::new(),
+            ReqOptions {
+                auth_token: None,
+                timeout: Duration::from_secs(1),
+                retry_on_initial_failure: true,
+                backoff_duration: Duration::from_secs(1),
+                retry_attempts: Some(3),
+                set_nodelay: true,
+                max_active_requests,
+            },
+        );
+
+        let addr_str = addr.to_string();
+        let connect_result = socket.connect(&addr_str).await;
+        assert!(
+            connect_result.is_ok(),
+            "Failed to connect: {:?}",
+            connect_result.err()
+        );
+
+        let request = Bytes::from_static(b"test request");
+        let mut futures = Vec::new();
+        for _ in 0..=max_active_requests {
+            futures.push(socket.request(request.clone()));
+        }
+
+        let results = futures::future::join_all(futures).await;
+
+        let num_successes = results.iter().filter(|res| res.is_ok()).count();
+        let num_failures = results.len() - num_successes;
+        assert_eq!(num_successes, max_active_requests);
+        assert_eq!(num_failures, 1);
     }
 }

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -35,7 +35,7 @@ impl<T: ClientTransport> ReqSocket<T> {
         Self {
             to_driver: None,
             transport,
-            options: Arc::new(options.clone()),
+            options: Arc::new(options),
             state: Arc::new(SocketState::default()),
             active_requests: Arc::new(AtomicUsize::new(0)),
         }


### PR DESCRIPTION
Tackled some TODOs I found in msg-socket
- added an error if endpoint invalid
- added limit the amount of active outgoing requests. Given this info, we can now pre-allocate the necessary memory to egress_queue and pending_requests

Had to change spawn_listener to continuously accept connections
