### PR TITLE
`flush_interval` for `ReqSocket` and `RepSocket` #14

### DIFF
--- a/msg-socket/src/rep/driver.rs
+++ b/msg-socket/src/rep/driver.rs
@@ -25,8 +25,6 @@ pub(crate) struct PeerState<T: AsyncRead + AsyncWrite> {
     addr: SocketAddr,
     egress_queue: VecDeque<reqrep::Message>,
     state: Arc<SocketState>,
-    flush_interval: Option<tokio::time::Interval>,
-    should_flush: bool,
 }
 
 pub(crate) struct RepDriver<T: ServerTransport> {
@@ -34,6 +32,7 @@ pub(crate) struct RepDriver<T: ServerTransport> {
     pub(crate) transport: T,
     /// The reply socket state, shared with the socket front-end.
     pub(crate) state: Arc<SocketState>,
+    #[allow(unused)]
     /// Options shared with socket.
     pub(crate) options: Arc<RepOptions>,
     /// [`StreamMap`] of connected peers. The key is the peer's address.
@@ -90,11 +89,6 @@ impl<T: ServerTransport> Future for RepDriver<T> {
                                 // TODO: pre-allocate according to some options
                                 egress_queue: VecDeque::with_capacity(64),
                                 state: Arc::clone(&this.state),
-                                flush_interval: this
-                                    .options
-                                    .flush_interval
-                                    .map(tokio::time::interval),
-                                should_flush: false,
                             }),
                         );
                     }
@@ -162,11 +156,6 @@ impl<T: ServerTransport> Future for RepDriver<T> {
                                 // TODO: pre-allocate according to some options
                                 egress_queue: VecDeque::with_capacity(64),
                                 state: Arc::clone(&this.state),
-                                flush_interval: this
-                                    .options
-                                    .flush_interval
-                                    .map(tokio::time::interval),
-                                should_flush: false,
                             }),
                         );
 
@@ -189,27 +178,6 @@ impl<T: ServerTransport> Future for RepDriver<T> {
     }
 }
 
-impl<T: AsyncRead + AsyncWrite> PeerState<T> {
-    #[inline]
-    fn should_flush(&mut self, cx: &mut Context<'_>) -> bool {
-        if self.should_flush {
-            if let Some(interval) = self.flush_interval.as_mut() {
-                interval.poll_tick(cx).is_ready()
-            } else {
-                true
-            }
-        } else {
-            // If we shouldn't flush, reset the interval so we don't get woken up
-            // every time the interval expires
-            if let Some(interval) = self.flush_interval.as_mut() {
-                interval.reset()
-            }
-
-            false
-        }
-    }
-}
-
 impl<T: AsyncRead + AsyncWrite + Unpin> Stream for PeerState<T> {
     type Item = Result<Request, PubError>;
 
@@ -219,11 +187,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for PeerState<T> {
 
         loop {
             // Flush any messages on the outgoing buffer
-            if this.should_flush(cx) {
-                if let Poll::Ready(Ok(_)) = this.conn.poll_flush_unpin(cx) {
-                    this.should_flush = false;
-                }
-            }
+            let _ = this.conn.poll_flush_unpin(cx);
 
             // Then, try to drain the egress queue.
             if this.conn.poll_ready_unpin(cx).is_ready() {
@@ -233,7 +197,6 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for PeerState<T> {
                         Ok(_) => {
                             this.state.stats.increment_tx(msg_len);
 
-                            this.should_flush = true;
                             // We might be able to send more queued messages
                             continue;
                         }

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -28,6 +28,7 @@ pub enum PubError {
 pub struct RepOptions {
     pub set_nodelay: bool,
     pub max_connections: Option<usize>,
+    pub flush_interval: Option<std::time::Duration>,
 }
 
 impl Default for RepOptions {
@@ -35,6 +36,7 @@ impl Default for RepOptions {
         Self {
             set_nodelay: true,
             max_connections: None,
+            flush_interval: None,
         }
     }
 }

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -28,7 +28,6 @@ pub enum PubError {
 pub struct RepOptions {
     pub set_nodelay: bool,
     pub max_connections: Option<usize>,
-    pub flush_interval: Option<std::time::Duration>,
 }
 
 impl Default for RepOptions {
@@ -36,7 +35,6 @@ impl Default for RepOptions {
         Self {
             set_nodelay: true,
             max_connections: None,
-            flush_interval: None,
         }
     }
 }

--- a/msg-socket/src/rep/socket.rs
+++ b/msg-socket/src/rep/socket.rs
@@ -75,6 +75,7 @@ impl<T: ServerTransport> RepSocket<T> {
 
         let backend = RepDriver {
             transport,
+            options: Arc::clone(&self.options),
             state: Arc::clone(&self.state),
             peer_states: StreamMap::with_capacity(self.options.max_connections.unwrap_or(64)),
             to_socket,

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -44,8 +44,12 @@ pub struct ReqOptions {
     pub timeout: std::time::Duration,
     pub retry_on_initial_failure: bool,
     pub backoff_duration: std::time::Duration,
-    /// The interval that the request connection should be flushed. Default this is `None`, and the connection is flushed after every send.
+    /// The interval that the request connection should be flushed.
+    /// Default is `None`, and the connection is flushed after every send.
     pub flush_interval: Option<std::time::Duration>,
+    /// The maximum number of bytes that can be buffered in the session before being flushed.
+    /// This internally sets [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
+    pub backpressure_boundary: usize,
     pub retry_attempts: Option<usize>,
     pub set_nodelay: bool,
 }
@@ -66,6 +70,7 @@ impl Default for ReqOptions {
             retry_on_initial_failure: true,
             backoff_duration: Duration::from_millis(200),
             flush_interval: None,
+            backpressure_boundary: 8192,
             retry_attempts: None,
             set_nodelay: true,
         }

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -44,6 +44,8 @@ pub struct ReqOptions {
     pub timeout: std::time::Duration,
     pub retry_on_initial_failure: bool,
     pub backoff_duration: std::time::Duration,
+    /// The interval that the request connection should be flushed. Default this is `None`, and the connection is flushed after every send.
+    pub flush_interval: Option<std::time::Duration>,
     pub retry_attempts: Option<usize>,
     pub set_nodelay: bool,
 }
@@ -63,6 +65,7 @@ impl Default for ReqOptions {
             timeout: std::time::Duration::from_secs(5),
             retry_on_initial_failure: true,
             backoff_duration: Duration::from_millis(200),
+            flush_interval: None,
             retry_attempts: None,
             set_nodelay: true,
         }

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -87,6 +87,8 @@ impl<T: ClientTransport> ReqSocket<T> {
             timeout_check_interval: tokio::time::interval(Duration::from_millis(
                 self.options.timeout.as_millis() as u64 / 10,
             )),
+            flush_interval: self.options.flush_interval.map(tokio::time::interval),
+            should_flush: false,
         };
 
         // Spawn the backend task
@@ -149,6 +151,7 @@ mod tests {
                 timeout: Duration::from_secs(1),
                 retry_on_initial_failure: true,
                 backoff_duration: Duration::from_secs(1),
+                flush_interval: None,
                 retry_attempts: Some(3),
                 set_nodelay: true,
             },
@@ -186,6 +189,7 @@ mod tests {
                 timeout: Duration::from_secs(1),
                 retry_on_initial_failure: true,
                 backoff_duration: Duration::from_secs(0),
+                flush_interval: None,
                 retry_attempts: None,
                 set_nodelay: true,
             },

--- a/msg/benches/reqrep.rs
+++ b/msg/benches/reqrep.rs
@@ -141,10 +141,13 @@ mod reqrep {
     }
 
     fn reqrep_with_runtime(bencher: divan::Bencher, rt: tokio::runtime::Runtime) {
-        //Note: Configure Tcp transport when #9 is merged.
         let mut req_socket = ReqSocket::with_options(
             Tcp::new_with_options(TcpOptions::default().with_blocking_connect()),
-            ReqOptions::default(),
+            ReqOptions {
+                // Add a flush interval to reduce the number of syscalls
+                flush_interval: Some(Duration::from_micros(50)),
+                ..Default::default()
+            },
         );
         let mut rep_socket = RepSocket::new(Tcp::new());
 


### PR DESCRIPTION
**Tasks**
- [x] Add flush_interval field in ReqOptions, default None
- [x] Respect flush_interval in req::Driver
~~- [x] Add flush_interval field in RepOptions, default None~~
~~- [x] Respect flush_interval in rep::PeerState~~

**Update**
Setting `flush_interval` for `RepOptions` results in benchmark throughput decreased. The reason is unknown yet and will investigate later.