### PR TITLE
Refactor: use builder pattern with socket options

### DIFF
--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -32,14 +32,14 @@ pub enum PubError {
 
 #[derive(Debug)]
 pub struct PubOptions {
-    pub max_clients: Option<usize>,
-    pub session_buffer_size: usize,
+    max_clients: Option<usize>,
+    session_buffer_size: usize,
     /// The interval at which each session should be flushed. If this is `None`,
     /// the session will be flushed on every publish, which can add a lot of overhead.
-    pub flush_interval: Option<std::time::Duration>,
+    flush_interval: Option<std::time::Duration>,
     /// The maximum number of bytes that can be buffered in the session before being flushed.
     /// This internally sets [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
-    pub backpressure_boundary: usize,
+    backpressure_boundary: usize,
 }
 
 impl Default for PubOptions {

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -76,8 +76,8 @@ impl PubOptions {
 
     /// Sets the interval at which each session should be flushed. If this is `None`,
     /// the session will be flushed on every publish, which can add a lot of overhead.
-    pub fn flush_interval(mut self, flush_interval: Option<std::time::Duration>) -> Self {
-        self.flush_interval = flush_interval;
+    pub fn flush_interval(mut self, flush_interval: std::time::Duration) -> Self {
+        self.flush_interval = Some(flush_interval);
         self
     }
 }

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -32,7 +32,9 @@ pub enum PubError {
 
 #[derive(Debug)]
 pub struct PubOptions {
+    /// The maximum number of concurrent clients.
     max_clients: Option<usize>,
+    /// The maximum number of outgoing messages that can be buffered per session.
     session_buffer_size: usize,
     /// The interval at which each session should be flushed. If this is `None`,
     /// the session will be flushed on every publish, which can add a lot of overhead.

--- a/msg-socket/src/rep/driver.rs
+++ b/msg-socket/src/rep/driver.rs
@@ -105,7 +105,7 @@ impl<T: ServerTransport> Future for RepDriver<T> {
             // Poll the transport for new incoming connections
             match this.transport.poll_accept(cx) {
                 Poll::Ready(Ok((stream, addr))) => {
-                    if let Some(max) = this.options.max_connections {
+                    if let Some(max) = this.options.max_clients {
                         if this.peer_states.len() >= max {
                             tracing::warn!(
                                 "Max connections reached ({}), rejecting connection from {}",

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -167,7 +167,7 @@ mod tests {
         // Initialize socket with a client ID. This will implicitly enable authentication.
         let mut req = ReqSocket::with_options(
             Tcp::new(),
-            ReqOptions::default().with_token(Bytes::from("REQ")),
+            ReqOptions::default().auth_token(Bytes::from("REQ")),
         );
 
         req.connect(&rep.local_addr().unwrap().to_string())

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -27,13 +27,13 @@ pub enum PubError {
 
 #[derive(Default)]
 pub struct RepOptions {
-    pub max_connections: Option<usize>,
+    pub max_clients: Option<usize>,
 }
 
 impl RepOptions {
-    /// Sets the maximum number of concurrent connections.
-    pub fn max_connections(mut self, max_connections: usize) -> Self {
-        self.max_connections = Some(max_connections);
+    /// Sets the number of maximum concurrent clients.
+    pub fn max_clients(mut self, max_clients: usize) -> Self {
+        self.max_clients = Some(max_clients);
         self
     }
 }
@@ -206,7 +206,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_rep_max_connections() {
         let _ = tracing_subscriber::fmt::try_init();
-        let mut rep = RepSocket::with_options(Tcp::new(), RepOptions::default().max_connections(1));
+        let mut rep = RepSocket::with_options(Tcp::new(), RepOptions::default().max_clients(1));
         rep.bind("127.0.0.1:0").await.unwrap();
 
         let mut req1 = ReqSocket::new(Tcp::new());

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -27,6 +27,7 @@ pub enum PubError {
 
 #[derive(Default)]
 pub struct RepOptions {
+    /// The maximum number of concurrent clients.
     max_clients: Option<usize>,
 }
 

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -27,7 +27,7 @@ pub enum PubError {
 
 #[derive(Default)]
 pub struct RepOptions {
-    pub max_clients: Option<usize>,
+    max_clients: Option<usize>,
 }
 
 impl RepOptions {

--- a/msg-socket/src/rep/socket.rs
+++ b/msg-socket/src/rep/socket.rs
@@ -80,7 +80,7 @@ impl<T: ServerTransport> RepSocket<T> {
             transport,
             options: Arc::clone(&self.options),
             state: Arc::clone(&self.state),
-            peer_states: StreamMap::with_capacity(self.options.max_connections.unwrap_or(64)),
+            peer_states: StreamMap::with_capacity(self.options.max_clients.unwrap_or(64)),
             to_socket,
             auth: self.auth.take(),
             auth_tasks: JoinSet::new(),

--- a/msg-socket/src/rep/socket.rs
+++ b/msg-socket/src/rep/socket.rs
@@ -60,7 +60,10 @@ impl<T: ServerTransport> RepSocket<T> {
         let (to_socket, from_backend) = mpsc::channel(DEFAULT_BUFFER_SIZE);
 
         // Take the transport here, so we can move it into the backend task
-        let mut transport = self.transport.take().unwrap();
+        let mut transport = self
+            .transport
+            .take()
+            .expect("Transport already taken, cannot bind multiple times");
 
         transport
             .bind(addr)

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -40,9 +40,13 @@ pub enum Command {
 
 #[derive(Debug, Clone)]
 pub struct ReqOptions {
+    /// The optional authentication token for the client.
     auth_token: Option<Bytes>,
+    /// Timeout duration for requests.
     timeout: std::time::Duration,
+    /// Wether to block on initial connection to the target.
     blocking_connect: bool,
+    /// The backoff duration for the underlying transport on reconnections.
     backoff_duration: std::time::Duration,
     /// The interval that the request connection should be flushed.
     /// Default is `None`, and the connection is flushed after every send.

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -42,7 +42,7 @@ pub enum Command {
 pub struct ReqOptions {
     pub auth_token: Option<Bytes>,
     pub timeout: std::time::Duration,
-    pub retry_on_initial_failure: bool,
+    pub blocking_connect: bool,
     pub backoff_duration: std::time::Duration,
     /// The interval that the request connection should be flushed.
     /// Default is `None`, and the connection is flushed after every send.
@@ -50,14 +50,53 @@ pub struct ReqOptions {
     /// The maximum number of bytes that can be buffered in the session before being flushed.
     /// This internally sets [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
     pub backpressure_boundary: usize,
+    /// The maximum number of retry attempts. If `None`, the connection will retry indefinitely.
     pub retry_attempts: Option<usize>,
-    pub set_nodelay: bool,
 }
 
 impl ReqOptions {
     /// Sets the authentication token for the socket.
-    pub fn with_token(mut self, auth_token: Bytes) -> Self {
+    pub fn auth_token(mut self, auth_token: Bytes) -> Self {
         self.auth_token = Some(auth_token);
+        self
+    }
+
+    /// Sets the timeout for the socket.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Enables blocking initial connections to the target.
+    pub fn blocking_connect(mut self) -> Self {
+        self.blocking_connect = true;
+        self
+    }
+
+    /// Sets the backoff duration for the socket.
+    pub fn backoff_duration(mut self, backoff_duration: Duration) -> Self {
+        self.backoff_duration = backoff_duration;
+        self
+    }
+
+    /// Sets the flush interval for the socket. A higher flush interval will result in higher throughput,
+    /// but at the cost of higher latency. Note that this behaviour can be completely useless if the
+    /// `backpressure_boundary` is set too low (which will trigger a flush before the interval is reached).
+    pub fn flush_interval(mut self, flush_interval: Duration) -> Self {
+        self.flush_interval = Some(flush_interval);
+        self
+    }
+
+    /// Sets the backpressure boundary for the socket. This is the maximum number of bytes that can be buffered
+    /// in the session before being flushed. This internally sets [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
+    pub fn backpressure_boundary(mut self, backpressure_boundary: usize) -> Self {
+        self.backpressure_boundary = backpressure_boundary;
+        self
+    }
+
+    /// Sets the maximum number of retry attempts. If `None`, all connections will be retried indefinitely.
+    pub fn retry_attempts(mut self, retry_attempts: usize) -> Self {
+        self.retry_attempts = Some(retry_attempts);
         self
     }
 }
@@ -67,12 +106,11 @@ impl Default for ReqOptions {
         Self {
             auth_token: None,
             timeout: std::time::Duration::from_secs(5),
-            retry_on_initial_failure: true,
+            blocking_connect: true,
             backoff_duration: Duration::from_millis(200),
             flush_interval: None,
             backpressure_boundary: 8192,
             retry_attempts: None,
-            set_nodelay: true,
         }
     }
 }

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -40,18 +40,18 @@ pub enum Command {
 
 #[derive(Debug, Clone)]
 pub struct ReqOptions {
-    pub auth_token: Option<Bytes>,
-    pub timeout: std::time::Duration,
-    pub blocking_connect: bool,
-    pub backoff_duration: std::time::Duration,
+    auth_token: Option<Bytes>,
+    timeout: std::time::Duration,
+    blocking_connect: bool,
+    backoff_duration: std::time::Duration,
     /// The interval that the request connection should be flushed.
     /// Default is `None`, and the connection is flushed after every send.
-    pub flush_interval: Option<std::time::Duration>,
+    flush_interval: Option<std::time::Duration>,
     /// The maximum number of bytes that can be buffered in the session before being flushed.
     /// This internally sets [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
-    pub backpressure_boundary: usize,
+    backpressure_boundary: usize,
     /// The maximum number of retry attempts. If `None`, the connection will retry indefinitely.
-    pub retry_attempts: Option<usize>,
+    retry_attempts: Option<usize>,
 }
 
 impl ReqOptions {

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -152,12 +152,11 @@ mod tests {
             ReqOptions {
                 auth_token: None,
                 timeout: Duration::from_secs(1),
-                retry_on_initial_failure: true,
+                blocking_connect: true,
                 backoff_duration: Duration::from_secs(1),
                 flush_interval: None,
                 backpressure_boundary: 8192,
                 retry_attempts: Some(3),
-                set_nodelay: true,
             },
         );
 
@@ -191,12 +190,11 @@ mod tests {
             ReqOptions {
                 auth_token: None,
                 timeout: Duration::from_secs(1),
-                retry_on_initial_failure: true,
+                blocking_connect: true,
                 backoff_duration: Duration::from_millis(200),
                 backpressure_boundary: 8192,
                 flush_interval: None,
                 retry_attempts: None,
-                set_nodelay: true,
             },
         );
 

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -55,9 +55,12 @@ enum Command {
 
 #[derive(Debug, Clone)]
 pub struct SubOptions {
+    /// The optional authentication token for the client.
     auth_token: Option<Bytes>,
-    timeout: std::time::Duration,
+    /// The maximum amount of incoming messages that will be buffered before being dropped due to
+    /// a slow consumer.
     ingress_buffer_size: usize,
+    /// The read buffer size for each session.
     read_buffer_size: usize,
 }
 
@@ -65,12 +68,6 @@ impl SubOptions {
     /// Sets the authentication token for the socket.
     pub fn auth_token(mut self, auth_token: Bytes) -> Self {
         self.auth_token = Some(auth_token);
-        self
-    }
-
-    /// Sets the timeout for the socket.
-    pub fn timeout(mut self, timeout: std::time::Duration) -> Self {
-        self.timeout = timeout;
         self
     }
 
@@ -94,7 +91,6 @@ impl Default for SubOptions {
             ingress_buffer_size: DEFAULT_BUFFER_SIZE,
             read_buffer_size: 8192,
             auth_token: None,
-            timeout: std::time::Duration::from_secs(5),
         }
     }
 }

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -63,8 +63,27 @@ pub struct SubOptions {
 
 impl SubOptions {
     /// Sets the authentication token for the socket.
-    pub fn with_token(mut self, auth_token: Bytes) -> Self {
+    pub fn auth_token(mut self, auth_token: Bytes) -> Self {
         self.auth_token = Some(auth_token);
+        self
+    }
+
+    /// Sets the timeout for the socket.
+    pub fn timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Sets the ingress buffer size. This is the maximum amount of incoming messages that will be buffered.
+    /// If the consumer cannot keep up with the incoming messages, messages will start being dropped.
+    pub fn ingress_buffer_size(mut self, ingress_buffer_size: usize) -> Self {
+        self.ingress_buffer_size = ingress_buffer_size;
+        self
+    }
+
+    /// Sets the read buffer size. This sets the size of the read buffer for each session.
+    pub fn read_buffer_size(mut self, read_buffer_size: usize) -> Self {
+        self.read_buffer_size = read_buffer_size;
         self
     }
 }

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -55,10 +55,10 @@ enum Command {
 
 #[derive(Debug, Clone)]
 pub struct SubOptions {
-    pub auth_token: Option<Bytes>,
-    pub timeout: std::time::Duration,
-    pub ingress_buffer_size: usize,
-    pub read_buffer_size: usize,
+    auth_token: Option<Bytes>,
+    timeout: std::time::Duration,
+    ingress_buffer_size: usize,
+    read_buffer_size: usize,
 }
 
 impl SubOptions {

--- a/msg/benches/pubsub.rs
+++ b/msg/benches/pubsub.rs
@@ -151,21 +151,17 @@ fn pubsub_single_thread_tcp(c: &mut Criterion) {
 
     let publisher = PubSocket::with_options(
         Tcp::new(),
-        PubOptions {
-            flush_interval: Some(Duration::from_micros(100)),
-            backpressure_boundary: buffer_size,
-            session_buffer_size: N_REQS * 2,
-            ..Default::default()
-        },
+        PubOptions::default()
+            .flush_interval(Duration::from_micros(100))
+            .backpressure_boundary(buffer_size)
+            .session_buffer_size(N_REQS * 2),
     );
 
     let subscriber = SubSocket::with_options(
         Tcp::new_with_options(TcpOptions::default().with_blocking_connect()),
-        SubOptions {
-            read_buffer_size: buffer_size,
-            ingress_buffer_size: N_REQS * 2,
-            ..Default::default()
-        },
+        SubOptions::default()
+            .read_buffer_size(buffer_size)
+            .ingress_buffer_size(N_REQS * 2),
     );
 
     let mut bench = PairBenchmark {
@@ -200,21 +196,17 @@ fn pubsub_multi_thread_tcp(c: &mut Criterion) {
 
     let publisher = PubSocket::with_options(
         Tcp::new(),
-        PubOptions {
-            flush_interval: Some(Duration::from_micros(100)),
-            backpressure_boundary: buffer_size,
-            session_buffer_size: N_REQS * 2,
-            ..Default::default()
-        },
+        PubOptions::default()
+            .flush_interval(Duration::from_micros(100))
+            .backpressure_boundary(buffer_size)
+            .session_buffer_size(N_REQS * 2),
     );
 
     let subscriber = SubSocket::with_options(
         Tcp::new_with_options(TcpOptions::default().with_blocking_connect()),
-        SubOptions {
-            read_buffer_size: buffer_size,
-            ingress_buffer_size: N_REQS * 2,
-            ..Default::default()
-        },
+        SubOptions::default()
+            .read_buffer_size(buffer_size)
+            .ingress_buffer_size(N_REQS * 2),
     );
 
     let mut bench = PairBenchmark {

--- a/msg/benches/reqrep.rs
+++ b/msg/benches/reqrep.rs
@@ -123,11 +123,7 @@ fn reqrep_single_thread_tcp(c: &mut Criterion) {
 
     let req = ReqSocket::with_options(
         Tcp::new(),
-        ReqOptions {
-            // Add a flush interval to reduce the number of syscalls
-            flush_interval: Some(Duration::from_micros(50)),
-            ..Default::default()
-        },
+        ReqOptions::default().flush_interval(Duration::from_micros(50)),
     );
 
     let rep = RepSocket::new(Tcp::new());
@@ -161,11 +157,7 @@ fn reqrep_multi_thread_tcp(c: &mut Criterion) {
 
     let req = ReqSocket::with_options(
         Tcp::new(),
-        ReqOptions {
-            // Add a flush interval to reduce the number of syscalls
-            flush_interval: Some(Duration::from_micros(50)),
-            ..Default::default()
-        },
+        ReqOptions::default().flush_interval(Duration::from_micros(50)),
     );
 
     let rep = RepSocket::new(Tcp::new());

--- a/msg/examples/durable.rs
+++ b/msg/examples/durable.rs
@@ -1,34 +1,61 @@
 use std::time::Duration;
 
 use bytes::Bytes;
+use tokio::sync::oneshot;
 use tokio_stream::StreamExt;
 
 use msg::{Authenticator, RepSocket, ReqOptions, ReqSocket, Tcp};
+use tracing::Instrument;
 
 #[derive(Default)]
 struct Auth;
 
 impl Authenticator for Auth {
     fn authenticate(&self, id: &Bytes) -> bool {
-        tracing::info!("Auth request from: {:?}", id);
+        tracing::info!("Auth request from: {:?}, authentication passed.", id);
         // Custom authentication logic
         true
     }
 }
 
+#[tracing::instrument(name = "RepSocket")]
 async fn start_rep() {
     // Initialize the reply socket (server side) with a transport
     // and an authenticator.
     let mut rep = RepSocket::new(Tcp::new()).with_auth(Auth);
-    rep.bind("0.0.0.0:4444").await.unwrap();
+    while rep.bind("0.0.0.0:4444").await.is_err() {
+        rep = RepSocket::new(Tcp::new()).with_auth(Auth);
+        tracing::warn!("Failed to bind rep socket, retrying...");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
 
     // Receive the request and respond with "world"
     // RepSocket implements `Stream`
-    let req = rep.next().await.unwrap();
-    tracing::info!("Message: {:?}", req.msg());
+    let mut n_reqs = 0;
+    loop {
+        let req = rep.next().await.unwrap();
+        n_reqs += 1;
+        tracing::info!("Message: {:?}", req.msg());
 
-    req.respond(Bytes::from("world")).unwrap();
-    tracing::warn!("Killing rep socket");
+        let msg = String::from_utf8_lossy(req.msg()).to_string();
+        let msg_id = msg
+            .split_whitespace()
+            .nth(1)
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+
+        if n_reqs == 5 {
+            tracing::warn!(
+                "RepSocket received the 5th request, dropping the request to trigger a timeout..."
+            );
+
+            continue;
+        }
+
+        let response = format!("PONG {msg_id}");
+        req.respond(Bytes::from(response)).unwrap();
+    }
 }
 
 #[tokio::main]
@@ -39,21 +66,61 @@ async fn main() {
     // and an identifier. This will implicitly turn on client authentication.
     let mut req = ReqSocket::with_options(
         Tcp::new(),
-        ReqOptions::default().with_token(Bytes::from("client1")),
+        ReqOptions {
+            auth_token: Some(Bytes::from("client1")),
+            timeout: Duration::from_secs(4),
+            ..Default::default()
+        },
     );
 
-    tracing::info!("Trying to connect to rep socket...");
-    req.connect("0.0.0.0:4444").await.unwrap();
-    tokio::spawn(async move {
-        tracing::info!("Sending request...");
-        let res: Bytes = req.request(Bytes::from("hello")).await.unwrap();
+    let (tx, rx) = oneshot::channel();
 
-        tracing::info!("Response: {:?}", res);
-    });
+    tokio::spawn(
+        async move {
+            tracing::info!("Trying to connect to rep socket... This will start the connection process in the background, it won't immediately connect.");
+            req.connect("0.0.0.0:4444").await.unwrap();
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    tracing::info!("Starting rep socket");
+            for i in 0..10 {
+                tracing::info!("Sending request {i}...");
+                if i == 0 {
+                    tracing::warn!("At this point the RepSocket is not running yet, so the request will block while \
+                    the ReqSocket continues to establish a connection. The RepSocket will be started in 3 seconds.");
+                }
+
+                let msg = format!("PING {i}");
+
+                let res = loop {
+                    match req.request(Bytes::from(msg.clone())).await {
+                        Ok(res) => break res,
+                        Err(e) => {
+                            tracing::error!("Request failed: {:?}, retrying...", e);
+                            tokio::time::sleep(Duration::from_millis(1000)).await;
+                        }
+                    }
+                };
+
+                tracing::info!("Response: {:?}", res);
+                tokio::time::sleep(Duration::from_millis(1000)).await;
+            }
+
+            tx.send(true).unwrap();
+        }
+        .instrument(tracing::info_span!("ReqSocket")),
+    );
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    tracing::info!("==========================");
+    tracing::info!("Starting the RepSocket now");
+    tracing::info!("==========================");
+
     tokio::spawn(start_rep());
+    // tokio::time::sleep(Duration::from_secs(2)).await;
+    // rep_task.abort();
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // tokio::spawn(start_rep());
+
+    // Wait for the client to finish
+    rx.await.unwrap();
+    tracing::info!("DONE. Sent all 10 PINGS and received 10 PONGS.");
 }

--- a/msg/examples/durable.rs
+++ b/msg/examples/durable.rs
@@ -66,11 +66,9 @@ async fn main() {
     // and an identifier. This will implicitly turn on client authentication.
     let mut req = ReqSocket::with_options(
         Tcp::new(),
-        ReqOptions {
-            auth_token: Some(Bytes::from("client1")),
-            timeout: Duration::from_secs(4),
-            ..Default::default()
-        },
+        ReqOptions::default()
+            .auth_token(Bytes::from("client1"))
+            .timeout(Duration::from_secs(4)),
     );
 
     let (tx, rx) = oneshot::channel();
@@ -115,10 +113,6 @@ async fn main() {
     tracing::info!("==========================");
 
     tokio::spawn(start_rep());
-    // tokio::time::sleep(Duration::from_secs(2)).await;
-    // rep_task.abort();
-
-    // tokio::spawn(start_rep());
 
     // Wait for the client to finish
     rx.await.unwrap();

--- a/msg/examples/pubsub.rs
+++ b/msg/examples/pubsub.rs
@@ -13,30 +13,22 @@ async fn main() {
     // Configure the publisher socket with options
     let mut pub_socket = PubSocket::with_options(
         Tcp::new(),
-        PubOptions {
-            backpressure_boundary: 8192,
-            session_buffer_size: 1024,
-            flush_interval: Some(Duration::from_micros(100)),
-            max_clients: None,
-        },
+        PubOptions::default()
+            .backpressure_boundary(8192)
+            .session_buffer_size(1024)
+            .flush_interval(Duration::from_micros(100)),
     );
 
     // Configure the subscribers with options
     let mut sub1 = SubSocket::with_options(
         // TCP transport with blocking connect, usually connection happens in the background.
         Tcp::new_with_options(TcpOptions::default().with_blocking_connect()),
-        SubOptions {
-            ingress_buffer_size: 1024,
-            ..Default::default()
-        },
+        SubOptions::default().ingress_buffer_size(1024),
     );
 
     let mut sub2 = SubSocket::with_options(
         Tcp::new_with_options(TcpOptions::default().with_blocking_connect()),
-        SubOptions {
-            ingress_buffer_size: 1024,
-            ..Default::default()
-        },
+        SubOptions::default().ingress_buffer_size(1024),
     );
 
     tracing::info!("Setting up the sockets...");

--- a/msg/examples/pubsub.rs
+++ b/msg/examples/pubsub.rs
@@ -17,7 +17,7 @@ async fn main() {
             backpressure_boundary: 8192,
             session_buffer_size: 1024,
             flush_interval: Some(Duration::from_micros(100)),
-            max_connections: None,
+            max_clients: None,
         },
     );
 

--- a/msg/examples/pubsub_auth.rs
+++ b/msg/examples/pubsub_auth.rs
@@ -33,7 +33,7 @@ async fn main() {
             backpressure_boundary: 8192,
             session_buffer_size: 1024,
             flush_interval: Some(Duration::from_micros(100)),
-            max_connections: None,
+            max_clients: None,
         },
     )
     // Enable the authenticator

--- a/msg/examples/pubsub_auth.rs
+++ b/msg/examples/pubsub_auth.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tracing::Instrument;
 
-use msg_socket::{Authenticator, PubOptions, PubSocket, SubOptions, SubSocket};
+use msg_socket::{Authenticator, PubSocket, SubOptions, SubSocket};
 use msg_transport::{Tcp, TcpOptions};
 
 #[derive(Default)]
@@ -27,38 +27,22 @@ impl Authenticator for Auth {
 async fn main() {
     let _ = tracing_subscriber::fmt::try_init();
     // Configure the publisher socket with options
-    let mut pub_socket = PubSocket::with_options(
-        Tcp::new(),
-        PubOptions {
-            backpressure_boundary: 8192,
-            session_buffer_size: 1024,
-            flush_interval: Some(Duration::from_micros(100)),
-            max_clients: None,
-        },
-    )
-    // Enable the authenticator
-    .with_auth(Auth);
+    let mut pub_socket = PubSocket::new(Tcp::new())
+        // Enable the authenticator
+        .with_auth(Auth);
 
     // Configure the subscribers with options
     let mut sub1 = SubSocket::with_options(
         // TCP transport with blocking connect, usually connection happens in the background.
         Tcp::new_with_options(TcpOptions::default().with_blocking_connect()),
-        SubOptions {
-            // Set the client ID for authentication
-            auth_token: Some(Bytes::from("client1")),
-            ingress_buffer_size: 1024,
-            ..Default::default()
-        },
+        // Set the auth token
+        SubOptions::default().auth_token(Bytes::from("client1")),
     );
 
     let mut sub2 = SubSocket::with_options(
         Tcp::new_with_options(TcpOptions::default().with_blocking_connect()),
-        SubOptions {
-            // Set the client ID for authentication. This client ID will be rejected.
-            auth_token: Some(Bytes::from("client2")),
-            ingress_buffer_size: 1024,
-            ..Default::default()
-        },
+        // Set the auth token
+        SubOptions::default().auth_token(Bytes::from("client2")),
     );
 
     tracing::info!("Setting up the sockets...");

--- a/msg/examples/reqrep_auth.rs
+++ b/msg/examples/reqrep_auth.rs
@@ -25,7 +25,7 @@ async fn main() {
     // and an identifier. This will implicitly turn on client authentication.
     let mut req = ReqSocket::with_options(
         Tcp::new(),
-        ReqOptions::default().with_token(Bytes::from("client1")),
+        ReqOptions::default().auth_token(Bytes::from("client1")),
     );
 
     req.connect("0.0.0.0:4444").await.unwrap();


### PR DESCRIPTION
This PR implements the builder pattern for all the socket options and uses that in the examples & benchmarks. It also fixed a bug where the `max_clients` option was not respected on server side sockets.