### PR TITLE
Fix latency stats underflow

### DIFF
--- a/msg-socket/src/sub/driver.rs
+++ b/msg-socket/src/sub/driver.rs
@@ -232,7 +232,7 @@ impl<Io: AsyncRead + AsyncWrite + Unpin> Stream for PublisherSession<Io> {
                         let now = unix_micros();
 
                         this.stats.increment_rx(msg.payload.len());
-                        this.stats.update_latency(now - msg.timestamp);
+                        this.stats.update_latency(now.saturating_sub(msg.timestamp));
                     }
 
                     return Poll::Ready(Some(result));


### PR DESCRIPTION
Uses `saturating_sub` instead of `-` for calculating latency. Had an issue with clock drift causing an unsigned integer underflow.