### PR TITLE
feat: Pub/Sub auto-decompression

### DIFF
--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -150,8 +150,8 @@ impl PubMessage {
 
     #[inline]
     pub fn compress(&mut self, compressor: &dyn Compressor) -> Result<(), io::Error> {
-        self.compression_type = compressor.compression_type();
         self.payload = compressor.compress(&self.payload)?;
+        self.compression_type = compressor.compression_type();
 
         Ok(())
     }

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -3,7 +3,10 @@ use std::io;
 use thiserror::Error;
 
 mod driver;
-use msg_wire::{compression::Compressor, pubsub};
+use msg_wire::{
+    compression::{CompressionType, Compressor},
+    pubsub,
+};
 mod session;
 mod socket;
 mod stats;
@@ -43,6 +46,9 @@ pub struct PubOptions {
     /// The maximum number of bytes that can be buffered in the session before being flushed.
     /// This internally sets [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
     backpressure_boundary: usize,
+    /// Minimum payload size in bytes for compression to be used. If the payload is smaller than
+    /// this threshold, it will not be compressed.
+    min_compress_size: usize,
 }
 
 impl Default for PubOptions {
@@ -52,6 +58,7 @@ impl Default for PubOptions {
             session_buffer_size: 1024,
             flush_interval: Some(std::time::Duration::from_micros(50)),
             backpressure_boundary: 8192,
+            min_compress_size: 1024,
         }
     }
 }
@@ -83,12 +90,21 @@ impl PubOptions {
         self.flush_interval = Some(flush_interval);
         self
     }
+
+    /// Sets the minimum payload size in bytes for compression to be used. If the payload is smaller than
+    /// this threshold, it will not be compressed.
+    pub fn min_compress_size(mut self, min_compress_size: usize) -> Self {
+        self.min_compress_size = min_compress_size;
+        self
+    }
 }
 
 /// A message received from a publisher.
 /// Includes the source, topic, and payload.
 #[derive(Debug, Clone)]
 pub struct PubMessage {
+    /// The compression type used for the message payload.
+    compression_type: CompressionType,
     /// The topic of the message.
     topic: String,
     /// The message payload.
@@ -98,7 +114,13 @@ pub struct PubMessage {
 #[allow(unused)]
 impl PubMessage {
     pub fn new(topic: String, payload: Bytes) -> Self {
-        Self { topic, payload }
+        Self {
+            // Initialize the compression type to None.
+            // The actual compression type will be set in the `compress` method.
+            compression_type: CompressionType::None,
+            topic,
+            payload,
+        }
     }
 
     #[inline]
@@ -118,11 +140,17 @@ impl PubMessage {
 
     #[inline]
     pub fn into_wire(self, seq: u32) -> pubsub::Message {
-        pubsub::Message::new(seq, Bytes::from(self.topic), self.payload)
+        pubsub::Message::new(
+            seq,
+            Bytes::from(self.topic),
+            self.payload,
+            self.compression_type,
+        )
     }
 
     #[inline]
     pub fn compress(&mut self, compressor: &dyn Compressor) -> Result<(), io::Error> {
+        self.compression_type = compressor.compression_type();
         self.payload = compressor.compress(&self.payload)?;
 
         Ok(())
@@ -141,7 +169,7 @@ mod tests {
 
     use futures::StreamExt;
     use msg_transport::{Tcp, TcpOptions};
-    use msg_wire::compression::{GzipCompressor, GzipDecompressor};
+    use msg_wire::compression::GzipCompressor;
 
     use crate::SubSocket;
 
@@ -216,16 +244,16 @@ mod tests {
     async fn pubsub_many_compressed() {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let mut pub_socket = PubSocket::new(Tcp::new()).with_compressor(GzipCompressor::new(6));
+        let mut pub_socket =
+            PubSocket::with_options(Tcp::new(), PubOptions::default().min_compress_size(0))
+                .with_compressor(GzipCompressor::new(6));
         let mut sub1 = SubSocket::new(Tcp::new_with_options(
             TcpOptions::default().with_blocking_connect(),
-        ))
-        .with_decompressor(GzipDecompressor::new());
+        ));
 
         let mut sub2 = SubSocket::new(Tcp::new_with_options(
             TcpOptions::default().with_blocking_connect(),
-        ))
-        .with_decompressor(GzipDecompressor::new());
+        ));
 
         pub_socket.bind("0.0.0.0:0").await.unwrap();
         let addr = pub_socket.local_addr().unwrap();

--- a/msg-socket/src/sub/socket.rs
+++ b/msg-socket/src/sub/socket.rs
@@ -10,7 +10,6 @@ use tokio::{sync::mpsc, task::JoinSet};
 use tokio_stream::StreamMap;
 
 use msg_transport::ClientTransport;
-use msg_wire::compression::Decompressor;
 
 use super::{
     Command, PubMessage, SocketState, SocketStats, SubDriver, SubError, SubOptions,
@@ -53,7 +52,6 @@ where
             transport: Arc::new(transport),
             from_socket,
             to_socket,
-            decompressor: None,
             connection_tasks: JoinSet::new(),
             publishers: StreamMap::with_capacity(24),
             subscribed_topics: HashSet::with_capacity(32),
@@ -68,17 +66,6 @@ where
             state,
             _marker: std::marker::PhantomData,
         }
-    }
-
-    /// Sets the payload decompressor for the socket. This decompressor will be used to decompress
-    /// all incoming messages from the publishers.
-    pub fn with_decompressor<C: Decompressor>(mut self, decompressor: C) -> Self {
-        self.driver
-            .as_mut()
-            .expect("Driver has been spawned already, cannot set compressor")
-            .set_decompressor(decompressor);
-
-        self
     }
 
     /// Asynchronously connects to the endpoint.

--- a/msg-wire/src/compression/gzip.rs
+++ b/msg-wire/src/compression/gzip.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use std::io::{self, Read, Write};
 
-use super::{Compressor, Decompressor};
+use super::{CompressionType, Compressor, Decompressor};
 
 /// A compressor that uses the gzip algorithm.
 pub struct GzipCompressor {
@@ -17,6 +17,10 @@ impl GzipCompressor {
 }
 
 impl Compressor for GzipCompressor {
+    fn compression_type(&self) -> CompressionType {
+        CompressionType::Gzip
+    }
+
     fn compress(&self, data: &[u8]) -> Result<Bytes, io::Error> {
         // Optimistically allocate the compressed buffer to 1/4 of the original size.
         let mut encoder = GzEncoder::new(

--- a/msg-wire/src/compression/mod.rs
+++ b/msg-wire/src/compression/mod.rs
@@ -6,9 +6,34 @@ mod zstd;
 pub use gzip::*;
 pub use zstd::*;
 
+/// The possible compression type used for a message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CompressionType {
+    None = 0,
+    Gzip = 1,
+    Zstd = 2,
+}
+
+impl TryFrom<u8> for CompressionType {
+    type Error = u8;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(CompressionType::None),
+            1 => Ok(CompressionType::Gzip),
+            2 => Ok(CompressionType::Zstd),
+            _ => Err(value),
+        }
+    }
+}
+
 /// This trait is used to implement message-level compression algorithms for payloads.
 /// On outgoing messages, the payload is compressed before being sent using the `compress` method.
 pub trait Compressor: Send + Sync + Unpin + 'static {
+    /// Returns the compression type assigned to this compressor.
+    fn compression_type(&self) -> CompressionType;
+
     /// Compresses a byte slice payload into a `Bytes` object.
     fn compress(&self, data: &[u8]) -> Result<Bytes, io::Error>;
 }

--- a/msg-wire/src/compression/zstd.rs
+++ b/msg-wire/src/compression/zstd.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use std::io;
 use zstd::{decode_all, stream::encode_all};
 
-use super::{Compressor, Decompressor};
+use super::{CompressionType, Compressor, Decompressor};
 
 pub struct ZstdCompressor {
     level: i32,
@@ -17,6 +17,10 @@ impl ZstdCompressor {
 }
 
 impl Compressor for ZstdCompressor {
+    fn compression_type(&self) -> CompressionType {
+        CompressionType::Zstd
+    }
+
     fn compress(&self, data: &[u8]) -> Result<Bytes, io::Error> {
         let compressed = encode_all(data, self.level)?;
 

--- a/msg/examples/pubsub_compression.rs
+++ b/msg/examples/pubsub_compression.rs
@@ -1,13 +1,10 @@
 use bytes::Bytes;
-use futures::StreamExt;
 use std::time::Duration;
 use tokio::time::timeout;
+use tokio_stream::StreamExt;
 use tracing::Instrument;
 
-use msg::{
-    compression::{GzipCompressor, GzipDecompressor},
-    PubSocket, SubSocket, Tcp, TcpOptions,
-};
+use msg::{compression::GzipCompressor, PubSocket, SubSocket, Tcp, TcpOptions};
 
 #[tokio::main]
 async fn main() {
@@ -21,14 +18,11 @@ async fn main() {
     let mut sub1 = SubSocket::new(
         // TCP transport with blocking connect, usually connection happens in the background.
         Tcp::new_with_options(TcpOptions::default().with_blocking_connect()),
-    )
-    // Enable Gzip decompression (at the same level)
-    .with_decompressor(GzipDecompressor::new());
+    );
 
     let mut sub2 = SubSocket::new(Tcp::new_with_options(
         TcpOptions::default().with_blocking_connect(),
-    ))
-    .with_decompressor(GzipDecompressor::new());
+    ));
 
     tracing::info!("Setting up the sockets...");
     pub_socket.bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
## Overview

- Added one `CompressionType` byte in pub/sub message headers, which enables the sub socket to decompress each message individually. More compression types can be added in the future by just extending this enum.
- Added a new `PubOption`: `min_compress_size` to set a payload size threshold under which to skip compression.

In practice, it is no longer necessary to specify a `Decompressor` when creating a `SubSocket`. This also solves the issue in #41 where the sub socket might have expected a specific compression type. 

## Benchmarks

Results are not clear yet, the existing pubsub bench didn't show any big difference, which is expected.
Probably a before / after profiler run will be useful here (yet todo).

---

- Closes #43 
- Closes #41 

