### PR TITLE
Perf: updated subscriber socket subsystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,9 @@ dependencies = [
 [[package]]
 name = "msg-common"
 version = "0.1.1"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "msg-socket"

--- a/msg-common/Cargo.toml
+++ b/msg-common/Cargo.toml
@@ -13,3 +13,4 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tokio.workspace = true

--- a/msg-common/src/lib.rs
+++ b/msg-common/src/lib.rs
@@ -1,4 +1,13 @@
-use std::time::SystemTime;
+use std::{
+    task::{Context, Poll},
+    time::SystemTime,
+};
+
+use tokio::sync::mpsc::{
+    self,
+    error::{SendError, TryRecvError, TrySendError},
+    Receiver, Sender,
+};
 
 /// Returns the current UNIX timestamp in microseconds.
 #[inline]
@@ -7,4 +16,106 @@ pub fn unix_micros() -> u64 {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         .as_micros() as u64
+}
+
+/// A bounded, bi-directional channel for sending and receiving messages.
+/// Relies on Tokio's [`mpsc`] channel.
+pub struct Channel<S, R> {
+    tx: Sender<S>,
+    rx: Receiver<R>,
+}
+
+/// Creates a new channel with the given buffer size. This will return a tuple of
+/// 2 [`Channel`]s, both of which can be used to send and receive messages.
+///
+/// It works with 2 generic types, `S` and `R`, which represent the types of
+/// messages that can be sent and received, respectively. The first channel in
+/// the tuple can be used to send messages of type `S` and receive messages of
+/// type `R`. The second channel can be used to send messages of type `R` and
+/// receive messages of type `S`.
+pub fn channel<S, R>(tx_buffer: usize, rx_buffer: usize) -> (Channel<S, R>, Channel<R, S>) {
+    let (tx1, rx1) = mpsc::channel(tx_buffer);
+    let (tx2, rx2) = mpsc::channel(rx_buffer);
+
+    (Channel { tx: tx1, rx: rx2 }, Channel { tx: tx2, rx: rx1 })
+}
+
+impl<S, R> Channel<S, R> {
+    /// Sends a value, waiting until there is capacity.
+    ///
+    /// A successful send occurs when it is determined that the other end of the
+    /// channel has not hung up already. An unsuccessful send would be one where
+    /// the corresponding receiver has already been closed. Note that a return
+    /// value of `Err` means that the data will never be received, but a return
+    /// value of `Ok` does not mean that the data will be received. It is
+    /// possible for the corresponding receiver to hang up immediately after
+    /// this function returns `Ok`.
+    pub async fn send(&mut self, msg: S) -> Result<(), SendError<S>> {
+        self.tx.send(msg).await
+    }
+
+    /// Attempts to immediately send a message on this [`Sender`]
+    ///
+    /// This method differs from [`send`] by returning immediately if the channel's
+    /// buffer is full or no receiver is waiting to acquire some data. Compared
+    /// with [`send`], this function has two failure cases instead of one (one for
+    /// disconnection, one for a full buffer).
+    pub fn try_send(&mut self, msg: S) -> Result<(), TrySendError<S>> {
+        self.tx.try_send(msg)
+    }
+
+    /// Receives the next value for this receiver.
+    ///
+    /// This method returns `None` if the channel has been closed and there are
+    /// no remaining messages in the channel's buffer. This indicates that no
+    /// further values can ever be received from this `Receiver`. The channel is
+    /// closed when all senders have been dropped, or when [`close`] is called.
+    ///
+    /// If there are no messages in the channel's buffer, but the channel has
+    /// not yet been closed, this method will sleep until a message is sent or
+    /// the channel is closed.  Note that if [`close`] is called, but there are
+    /// still outstanding [`Permits`] from before it was closed, the channel is
+    /// not considered closed by `recv` until the permits are released.
+    pub async fn recv(&mut self) -> Option<R> {
+        self.rx.recv().await
+    }
+
+    /// Tries to receive the next value for this receiver.
+    ///
+    /// This method returns the [`Empty`](TryRecvError::Empty) error if the channel is currently
+    /// empty, but there are still outstanding [senders] or [permits].
+    ///
+    /// This method returns the [`Disconnected`](TryRecvError::Disconnected) error if the channel is
+    /// currently empty, and there are no outstanding [senders] or [permits].
+    ///
+    /// Unlike the [`poll_recv`](Self::poll_recv) method, this method will never return an
+    /// [`Empty`](TryRecvError::Empty) error spuriously.
+    pub fn try_recv(&mut self) -> Result<R, TryRecvError> {
+        self.rx.try_recv()
+    }
+
+    /// Polls to receive the next message on this channel.
+    ///
+    /// This method returns:
+    ///
+    ///  * `Poll::Pending` if no messages are available but the channel is not
+    ///    closed, or if a spurious failure happens.
+    ///  * `Poll::Ready(Some(message))` if a message is available.
+    ///  * `Poll::Ready(None)` if the channel has been closed and all messages
+    ///    sent before it was closed have been received.
+    ///
+    /// When the method returns `Poll::Pending`, the `Waker` in the provided
+    /// `Context` is scheduled to receive a wakeup when a message is sent on any
+    /// receiver, or when the channel is closed.  Note that on multiple calls to
+    /// `poll_recv`, only the `Waker` from the `Context` passed to the most
+    /// recent call is scheduled to receive a wakeup.
+    ///
+    /// If this method returns `Poll::Pending` due to a spurious failure, then
+    /// the `Waker` will be notified when the situation causing the spurious
+    /// failure has been resolved. Note that receiving such a wakeup does not
+    /// guarantee that the next call will succeed — it could fail with another
+    /// spurious failure.
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<R>> {
+        self.rx.poll_recv(cx)
+    }
 }

--- a/msg-socket/src/sub/driver.rs
+++ b/msg-socket/src/sub/driver.rs
@@ -1,23 +1,22 @@
-use bytes::Bytes;
-use futures::{Future, Stream, StreamExt};
-use std::collections::{HashSet, VecDeque};
+use futures::Future;
+use rustc_hash::FxHashMap;
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::{sync::mpsc, task::JoinSet};
-use tokio_stream::StreamMap;
 use tokio_util::codec::Framed;
-use tracing::{debug, error};
+use tracing::{debug, error, info, warn};
 
-use super::stats::SessionStats;
+use super::session::SessionCommand;
 use super::{
+    session::PublisherSession,
     stream::{PublisherStream, TopicMessage},
     Command, PubMessage, SocketState, SubOptions,
 };
-use msg_common::unix_micros;
+use msg_common::{channel, Channel};
 use msg_transport::ClientTransport;
 use msg_wire::pubsub;
 
@@ -37,7 +36,7 @@ pub(crate) struct SubDriver<T: ClientTransport> {
     /// The set of subscribed topics.
     pub(super) subscribed_topics: HashSet<String>,
     /// All active publisher sessions for this subscriber socket.
-    pub(super) publishers: StreamMap<SocketAddr, PublisherSession<T::Io>>,
+    pub(super) publishers: FxHashMap<SocketAddr, Channel<SessionCommand, TopicMessage>>,
     /// Socket state. This is shared with the backend task.
     pub(super) state: Arc<SocketState>,
 }
@@ -53,29 +52,8 @@ where
         let this = self.get_mut();
 
         loop {
-            if let Poll::Ready(Some((addr, result))) = this.publishers.poll_next_unpin(cx) {
-                match result {
-                    Ok(mut msg) => {
-                        match msg.try_decompress() {
-                            None => { /* No decompression necessary */ }
-                            Some(Ok(decompressed)) => msg.payload = decompressed,
-                            Some(Err(e)) => {
-                                error!(
-                                    topic = msg.topic.as_str(),
-                                    "Failed to decompress message payload: {:?}", e
-                                );
-
-                                continue;
-                            }
-                        }
-
-                        this.on_message(PubMessage::new(addr, msg.topic, msg.payload));
-                    }
-                    Err(e) => {
-                        error!(source = %addr, "Error receiving message from publisher: {:?}", e);
-                    }
-                }
-
+            // First, poll all the publishers to handle incoming messages.
+            if this.poll_publishers(cx).is_ready() {
                 continue;
             }
 
@@ -107,28 +85,77 @@ impl<T> SubDriver<T>
 where
     T: ClientTransport + Send + Sync + 'static,
 {
+    /// Subscribes to a topic on all publishers.
+    fn subscribe(&mut self, topic: String) {
+        let mut inactive = Vec::new();
+
+        if self.subscribed_topics.insert(topic.clone()) {
+            // Subscribe to the topic on all publishers
+
+            for (addr, publisher_channel) in self.publishers.iter_mut() {
+                // If the channel is closed on the other side, remove it from the list of publishers.
+                if let Err(TrySendError::Closed(_)) =
+                    publisher_channel.try_send(SessionCommand::Subscribe(topic.clone()))
+                {
+                    warn!(publisher = %addr, "Error trying to subscribe to topic {topic}: publisher channel closed");
+                    inactive.push(*addr);
+                }
+            }
+
+            // Remove all inactive publishers
+            for addr in inactive {
+                self.publishers.remove(&addr);
+            }
+
+            info!(
+                topic = topic.as_str(),
+                n_publishers = self.publishers.len(),
+                "Subscribed to topic"
+            );
+        } else {
+            debug!(topic = topic.as_str(), "Already subscribed to topic");
+        }
+    }
+
+    /// Unsubscribes from a topic on all publishers.
+    fn unsubscribe(&mut self, topic: String) {
+        let mut inactive = Vec::new();
+
+        if self.subscribed_topics.remove(&topic) {
+            // Unsubscribe from the topic on all publishers
+            for (addr, publisher_channel) in self.publishers.iter_mut() {
+                // If the channel is closed on the other side, remove it from the list of publishers.
+                if let Err(TrySendError::Closed(_)) =
+                    publisher_channel.try_send(SessionCommand::Unsubscribe(topic.clone()))
+                {
+                    warn!(publisher = %addr, "Error trying to unsubscribe from topic {topic}: publisher channel closed");
+                    inactive.push(*addr);
+                }
+            }
+
+            // Remove all inactive publishers
+            for addr in inactive {
+                self.publishers.remove(&addr);
+            }
+
+            info!(
+                topic = topic.as_str(),
+                n_publishers = self.publishers.len(),
+                "Unsubscribed from topic"
+            );
+        } else {
+            debug!(topic = topic.as_str(), "Not subscribed to topic");
+        }
+    }
+
     fn on_command(&mut self, cmd: Command) {
         debug!("Received command: {:?}", cmd);
         match cmd {
             Command::Subscribe { topic } => {
-                if !self.subscribed_topics.contains(&topic) {
-                    self.subscribed_topics.insert(topic.clone());
-                    // Subscribe to the topic on all publishers
-                    for session in self.publishers.values_mut() {
-                        session.subscribe(topic.clone());
-                    }
-                } else {
-                    debug!(topic = topic.as_str(), "Already subscribed to topic");
-                }
+                self.subscribe(topic);
             }
             Command::Unsubscribe { topic } => {
-                if self.subscribed_topics.remove(&topic) {
-                    for session in self.publishers.values_mut() {
-                        session.unsubscribe(topic.clone());
-                    }
-                } else {
-                    debug!(topic = topic.as_str(), "Not subscribed to topic");
-                }
+                self.unsubscribe(topic);
             }
             Command::Connect { endpoint } => {
                 let id = self.options.auth_token.clone();
@@ -155,124 +182,93 @@ where
         }
     }
 
-    fn on_message(&self, msg: PubMessage) {
-        debug!(source = %msg.source, "New message: {:?}", msg);
-        // TODO: queuing
-        if let Err(TrySendError::Full(msg)) = self.to_socket.try_send(msg) {
-            error!(
-                topic = msg.topic,
-                "Slow subscriber socket, dropping message"
-            );
-        }
-    }
-
     fn on_connection(&mut self, addr: SocketAddr, io: T::Io) {
         // This should spawn a new task tied to this connection, and
         debug!("Connection to {} established, spawning session", addr);
 
         let framed = Framed::with_capacity(io, pubsub::Codec::new(), self.options.read_buffer_size);
 
-        let mut publisher_session = PublisherSession::new(addr, PublisherStream::new(framed));
+        let (driver_channel, mut publisher_channel) = channel(1024, 64);
+
+        let publisher_session =
+            PublisherSession::new(addr, PublisherStream::new(framed), driver_channel);
+
         // Get the shared session stats.
         let session_stats = publisher_session.stats();
 
+        // Spawn the publisher session
+        tokio::spawn(publisher_session);
+
         for topic in self.subscribed_topics.iter() {
-            publisher_session.subscribe(topic.clone());
+            if publisher_channel
+                .try_send(SessionCommand::Subscribe(topic.clone()))
+                .is_err()
+            {
+                error!(publisher = %addr, "Error trying to subscribe to topic {topic} on startup: publisher channel closed / full");
+            }
         }
 
-        self.publishers.insert(addr, publisher_session);
+        self.publishers.insert(addr, publisher_channel);
         self.state.stats.insert(addr, session_stats);
     }
-}
 
-/// Manages the state of a single publisher, represented as a [`Stream`].
-#[must_use = "streams do nothing unless polled"]
-pub(super) struct PublisherSession<Io> {
-    /// The addr of the publisher
-    addr: SocketAddr,
-    /// The egress queue (for subscribe / unsubscribe messages)
-    egress: VecDeque<pubsub::Message>,
-    /// The inner stream
-    stream: PublisherStream<Io>,
-    /// The session stats
-    stats: Arc<SessionStats>,
-}
+    /// Polls all the publisher channels for new messages. On new messages, forwards them to the socket.
+    /// If a publisher channel is closed, it will be removed from the list of publishers.
+    ///
+    /// Returns `Poll::Ready` if any progress was made and this method should be called again.
+    /// Returns `Poll::Pending` if no progress was made.
+    fn poll_publishers(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        let mut progress = false;
 
-impl<Io: AsyncRead + AsyncWrite + Send + Unpin> PublisherSession<Io> {
-    fn new(addr: SocketAddr, stream: PublisherStream<Io>) -> Self {
-        Self {
-            addr,
-            stream,
-            egress: VecDeque::with_capacity(4),
-            stats: Arc::new(SessionStats::default()),
-        }
-    }
+        let mut inactive = Vec::new();
 
-    /// Returns a reference to the session stats.
-    fn stats(&self) -> Arc<SessionStats> {
-        Arc::clone(&self.stats)
-    }
+        for (addr, rx) in self.publishers.iter_mut() {
+            match rx.poll_recv(cx) {
+                Poll::Ready(Some(mut msg)) => {
+                    match msg.try_decompress() {
+                        None => { /* No decompression necessary */ }
+                        Some(Ok(decompressed)) => msg.payload = decompressed,
+                        Some(Err(e)) => {
+                            error!(
+                                topic = msg.topic.as_str(),
+                                "Failed to decompress message payload: {:?}", e
+                            );
 
-    /// Queues a subscribe message for this publisher.
-    /// On the next poll, the message will be attempted to be sent.
-    fn subscribe(&mut self, topic: String) {
-        self.egress
-            .push_back(pubsub::Message::new_sub(Bytes::from(topic)));
-    }
-
-    /// Queues an unsubscribe message for this publisher.
-    /// On the next poll, the message will be attempted to be sent.
-    fn unsubscribe(&mut self, topic: String) {
-        self.egress
-            .push_back(pubsub::Message::new_unsub(Bytes::from(topic)));
-    }
-}
-
-impl<Io: AsyncRead + AsyncWrite + Unpin> Stream for PublisherSession<Io> {
-    type Item = Result<TopicMessage, pubsub::Error>;
-
-    /// This poll implementation prioritizes incoming messages over outgoing messages.
-    #[inline]
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        loop {
-            match this.stream.poll_next_unpin(cx) {
-                Poll::Ready(Some(result)) => {
-                    // Update session stats
-                    if let Ok(ref msg) = result {
-                        let now = unix_micros();
-
-                        this.stats.increment_rx(msg.payload.len());
-                        this.stats.update_latency(now.saturating_sub(msg.timestamp));
+                            continue;
+                        }
                     }
 
-                    return Poll::Ready(Some(result));
+                    let msg = PubMessage::new(*addr, msg.topic, msg.payload);
+
+                    debug!(source = %msg.source, "New message: {:?}", msg);
+                    // TODO: queuing
+                    if let Err(TrySendError::Full(msg)) = self.to_socket.try_send(msg) {
+                        error!(
+                            topic = msg.topic,
+                            "Slow subscriber socket, dropping message"
+                        );
+                    }
+
+                    progress = true;
                 }
                 Poll::Ready(None) => {
-                    error!(addr = %this.addr, "Publisher stream closed");
-                    return Poll::Ready(None);
+                    error!(source = %addr, "Publisher stream closed, removing channel");
+                    inactive.push(*addr);
+
+                    progress = true;
                 }
                 Poll::Pending => {}
             }
+        }
 
-            let mut progress = false;
-            while let Some(msg) = this.egress.pop_front() {
-                // TODO(perf): do we need to clone the message here?
-                if this.stream.poll_send(cx, msg.clone()).is_ready() {
-                    progress = true;
-                    debug!("Queued message for sending: {:?}", msg);
-                } else {
-                    this.egress.push_back(msg);
-                    break;
-                }
-            }
+        for addr in inactive {
+            self.publishers.remove(&addr);
+        }
 
-            if progress {
-                continue;
-            }
-
-            return Poll::Pending;
+        if progress {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
         }
     }
 }

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use thiserror::Error;
 
 mod driver;
+mod session;
 mod socket;
 mod stats;
 mod stream;

--- a/msg-socket/src/sub/session.rs
+++ b/msg-socket/src/sub/session.rs
@@ -1,0 +1,157 @@
+use bytes::Bytes;
+use futures::{Future, StreamExt};
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::{debug, error, warn};
+
+use msg_common::{unix_micros, Channel};
+use msg_wire::pubsub;
+
+use super::{
+    stats::SessionStats,
+    stream::{PublisherStream, TopicMessage},
+};
+
+pub(super) enum SessionCommand {
+    Subscribe(String),
+    Unsubscribe(String),
+}
+
+/// Manages the state of a single publisher, represented as a [`Future`].
+#[must_use = "This future must be spawned"]
+pub(super) struct PublisherSession<Io> {
+    /// The addr of the publisher
+    addr: SocketAddr,
+    /// The egress queue (for subscribe / unsubscribe messages)
+    egress: VecDeque<pubsub::Message>,
+    /// The inner stream
+    stream: PublisherStream<Io>,
+    /// The session stats
+    stats: Arc<SessionStats>,
+    /// Channel for bi-directional communication with the driver. Sends new messages from the associated
+    /// publisher and receives subscribe / unsubscribe commands.
+    driver_channel: Channel<TopicMessage, SessionCommand>,
+}
+
+impl<Io: AsyncRead + AsyncWrite + Unpin> PublisherSession<Io> {
+    pub(super) fn new(
+        addr: SocketAddr,
+        stream: PublisherStream<Io>,
+        channel: Channel<TopicMessage, SessionCommand>,
+    ) -> Self {
+        Self {
+            addr,
+            stream,
+            egress: VecDeque::with_capacity(4),
+            stats: Arc::new(SessionStats::default()),
+            driver_channel: channel,
+        }
+    }
+
+    /// Returns a reference to the session stats.
+    pub(super) fn stats(&self) -> Arc<SessionStats> {
+        Arc::clone(&self.stats)
+    }
+
+    /// Queues a subscribe message for this publisher.
+    /// On the next poll, the message will be attempted to be sent.
+    fn subscribe(&mut self, topic: String) {
+        self.egress
+            .push_back(pubsub::Message::new_sub(Bytes::from(topic)));
+    }
+
+    /// Queues an unsubscribe message for this publisher.
+    /// On the next poll, the message will be attempted to be sent.
+    fn unsubscribe(&mut self, topic: String) {
+        self.egress
+            .push_back(pubsub::Message::new_unsub(Bytes::from(topic)));
+    }
+
+    /// Handles incoming messages. On a successful message, the session stats are updated and the message
+    /// is forwarded to the driver.
+    fn on_incoming(&mut self, incoming: Result<TopicMessage, pubsub::Error>) {
+        match incoming {
+            Ok(msg) => {
+                let now = unix_micros();
+
+                self.stats.increment_rx(msg.payload.len());
+                self.stats.update_latency(now.saturating_sub(msg.timestamp));
+
+                if self.driver_channel.try_send(msg).is_err() {
+                    warn!(addr = %self.addr, "Failed to send message to driver");
+                }
+            }
+            Err(e) => {
+                error!(addr = %self.addr, "Error receiving message: {:?}", e);
+            }
+        }
+    }
+
+    fn on_command(&mut self, cmd: SessionCommand) {
+        match cmd {
+            SessionCommand::Subscribe(topic) => self.subscribe(topic),
+            SessionCommand::Unsubscribe(topic) => self.unsubscribe(topic),
+        }
+    }
+}
+
+impl<Io: AsyncRead + AsyncWrite + Unpin> Future for PublisherSession<Io> {
+    type Output = ();
+
+    /// This poll implementation prioritizes incoming messages over outgoing messages.
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        loop {
+            match this.stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(result)) => {
+                    // Update session stats
+
+                    this.on_incoming(result);
+                    continue;
+                }
+                Poll::Ready(None) => {
+                    error!(addr = %this.addr, "Publisher stream closed");
+                    return Poll::Ready(());
+                }
+                Poll::Pending => {}
+            }
+
+            let mut progress = false;
+            while let Some(msg) = this.egress.pop_front() {
+                // TODO(perf): do we need to clone the message here?
+                if this.stream.poll_send(cx, msg.clone()).is_ready() {
+                    progress = true;
+                    debug!("Queued message for sending: {:?}", msg);
+                } else {
+                    this.egress.push_back(msg);
+                    break;
+                }
+            }
+
+            if progress {
+                continue;
+            }
+
+            if let Poll::Ready(item) = this.driver_channel.poll_recv(cx) {
+                match item {
+                    Some(cmd) => {
+                        this.on_command(cmd);
+                        continue;
+                    }
+                    None => {
+                        warn!(addr = %this.addr, "Driver channel closed, shutting down session");
+                        return Poll::Ready(());
+                    }
+                }
+            }
+
+            return Poll::Pending;
+        }
+    }
+}

--- a/msg-socket/src/sub/socket.rs
+++ b/msg-socket/src/sub/socket.rs
@@ -1,4 +1,5 @@
 use futures::Stream;
+use rustc_hash::FxHashMap;
 use std::{
     collections::HashSet,
     net::SocketAddr,
@@ -7,7 +8,6 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::{sync::mpsc, task::JoinSet};
-use tokio_stream::StreamMap;
 
 use msg_transport::ClientTransport;
 
@@ -47,13 +47,16 @@ where
 
         let state = Arc::new(SocketState::default());
 
+        let mut publishers = FxHashMap::default();
+        publishers.reserve(32);
+
         let driver = SubDriver {
             options: Arc::clone(&options),
             transport: Arc::new(transport),
             from_socket,
             to_socket,
             connection_tasks: JoinSet::new(),
-            publishers: StreamMap::with_capacity(24),
+            publishers,
             subscribed_topics: HashSet::with_capacity(32),
             state: Arc::clone(&state),
         };


### PR DESCRIPTION
## Context
Previously all `PublisherSessions` (the components keeping track of a publisher connection inside of a `SubSocket`) where being polled in the same task, because they were all stored in a `StreamMap`. For small messages and a small number of sessions this is fine, but it means that:

- All reading from / writing to socket buffers
- All message encoding / decoding
- All compression / decompression

For *each* of the active publisher sessions where happening in a single task.

## Updates
This PR spawns each publisher session as a separate task and implements a bi-directional communication channel between the `SubDriver` and all of the `PublisherSessions`. This should be more efficient for larger messages, mixed workloads, and multiple publishers.