### PR TITLE
feat(qol): use `ToSocketAddrs` for public-facing socket apis

### DIFF
--- a/book/src/usage/transport-layers.md
+++ b/book/src/usage/transport-layers.md
@@ -6,12 +6,12 @@ layers are supported:
 
 - [TCP](#tcp)
 - [QUIC](#quic)
+
 <!--
 - [IPC](#ipc)
 - [Inproc](#inproc)
 - [UDP](#udp)
 - [TLS](#tls)
-- [QUIC](#quic)
   -->
 
 ## TCP
@@ -38,10 +38,14 @@ use msg::{RepSocket, ReqSocket, Tcp};
 async fn main() {
     // Initialize the reply socket (server side) with default TCP
     let mut rep = RepSocket::new(Tcp::default());
+    // Bind the socket to the address. This will start listening for incoming connections.
+    // This method does DNS resolution internally, so you can use hostnames here.
     rep.bind("0.0.0.0:4444").await.unwrap();
 
     // Initialize the request socket (client side) with default TCP
     let mut req = ReqSocket::new(Tcp::default());
+    // Connect the socket to the address. This will initiate a connection to the server.
+    // This method does DNS resolution internally, so you can use hostnames here.
     req.connect("0.0.0.0:4444").await.unwrap();
 
     // ...
@@ -75,10 +79,14 @@ use msg::{RepSocket, ReqSocket, Quic};
 async fn main() {
     // Initialize the reply socket (server side) with default QUIC
     let mut rep = RepSocket::new(Quic::default());
+    // Bind the socket to the address. This will start listening for incoming connections.
+    // This method does DNS resolution internally, so you can use hostnames here.
     rep.bind("0.0.0.0:4444").await.unwrap();
 
     // Initialize the request socket (client side) with default QUIC
     let mut req = ReqSocket::new(Quic::default());
+    // Connect the socket to the address. This will initiate a connection to the server.
+    // This method does DNS resolution internally, so you can use hostnames here.
     req.connect("0.0.0.0:4444").await.unwrap();
 
     // ...

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -17,7 +17,7 @@ use stats::SocketStats;
 #[derive(Debug, Error)]
 pub enum PubError {
     #[error("IO error: {0:?}")]
-    Io(#[from] std::io::Error),
+    Io(#[from] io::Error),
     #[error("Wire protocol error: {0:?}")]
     Wire(#[from] msg_wire::reqrep::Error),
     #[error("Authentication error: {0}")]
@@ -192,7 +192,7 @@ mod tests {
 
         let mut sub_socket = SubSocket::with_options(Tcp::default(), SubOptions::default());
 
-        pub_socket.bind("0.0.0.0:0".parse().unwrap()).await.unwrap();
+        pub_socket.bind("0.0.0.0:0").await.unwrap();
         let addr = pub_socket.local_addr().unwrap();
 
         sub_socket.connect(addr).await.unwrap();
@@ -221,7 +221,7 @@ mod tests {
             SubOptions::default().auth_token(Bytes::from("client1")),
         );
 
-        pub_socket.bind("0.0.0.0:0".parse().unwrap()).await.unwrap();
+        pub_socket.bind("0.0.0.0:0").await.unwrap();
         let addr = pub_socket.local_addr().unwrap();
 
         sub_socket.connect(addr).await.unwrap();
@@ -250,7 +250,7 @@ mod tests {
             SubOptions::default().auth_token(Bytes::from("client1")),
         );
 
-        pub_socket.bind("0.0.0.0:0".parse().unwrap()).await.unwrap();
+        pub_socket.bind("0.0.0.0:0").await.unwrap();
         let addr = pub_socket.local_addr().unwrap();
 
         sub_socket.connect(addr).await.unwrap();
@@ -278,7 +278,7 @@ mod tests {
 
         let mut sub2 = SubSocket::new(Tcp::default());
 
-        pub_socket.bind("0.0.0.0:0".parse().unwrap()).await.unwrap();
+        pub_socket.bind("0.0.0.0:0").await.unwrap();
         let addr = pub_socket.local_addr().unwrap();
 
         sub1.connect(addr).await.unwrap();
@@ -313,7 +313,7 @@ mod tests {
 
         let mut sub2 = SubSocket::new(Tcp::default());
 
-        pub_socket.bind("0.0.0.0:0".parse().unwrap()).await.unwrap();
+        pub_socket.bind("0.0.0.0:0").await.unwrap();
         let addr = pub_socket.local_addr().unwrap();
 
         sub1.connect(addr).await.unwrap();
@@ -349,17 +349,11 @@ mod tests {
         let mut sub_socket = SubSocket::new(Tcp::default());
 
         // Try to connect and subscribe before the publisher is up
-        sub_socket
-            .connect("0.0.0.0:6662".parse().unwrap())
-            .await
-            .unwrap();
+        sub_socket.connect("0.0.0.0:6662").await.unwrap();
         sub_socket.subscribe("HELLO".to_string()).await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        pub_socket
-            .bind("0.0.0.0:6662".parse().unwrap())
-            .await
-            .unwrap();
+        pub_socket.bind("0.0.0.0:6662").await.unwrap();
         tokio::time::sleep(Duration::from_millis(2000)).await;
 
         pub_socket
@@ -382,17 +376,11 @@ mod tests {
         let mut sub_socket = SubSocket::new(Quic::default());
 
         // Try to connect and subscribe before the publisher is up
-        sub_socket
-            .connect("0.0.0.0:6662".parse().unwrap())
-            .await
-            .unwrap();
+        sub_socket.connect("0.0.0.0:6662").await.unwrap();
         sub_socket.subscribe("HELLO".to_string()).await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        pub_socket
-            .bind("0.0.0.0:6662".parse().unwrap())
-            .await
-            .unwrap();
+        pub_socket.bind("0.0.0.0:6662").await.unwrap();
         tokio::time::sleep(Duration::from_millis(2000)).await;
 
         pub_socket
@@ -413,7 +401,7 @@ mod tests {
         let mut pub_socket =
             PubSocket::with_options(Tcp::default(), PubOptions::default().max_clients(1));
 
-        pub_socket.bind("0.0.0.0:0".parse().unwrap()).await.unwrap();
+        pub_socket.bind("0.0.0.0:0").await.unwrap();
 
         let mut sub1 = SubSocket::<Tcp>::with_options(Tcp::default(), SubOptions::default());
 

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -132,8 +132,8 @@ mod tests {
 
         // Initialize the request socket (client side) with a transport
         let mut req = ReqSocket::new(Tcp::default());
-        let endpoint = addr.parse().unwrap();
         // Try to connect even through the server isn't up yet
+        let endpoint = addr.clone();
         let connection_attempt = tokio::spawn(async move {
             req.connect(endpoint).await.unwrap();
 
@@ -143,7 +143,7 @@ mod tests {
         // Wait a moment to start the server
         tokio::time::sleep(Duration::from_millis(500)).await;
         let mut rep = RepSocket::new(Tcp::default());
-        rep.bind(addr.parse().unwrap()).await.unwrap();
+        rep.bind(addr).await.unwrap();
 
         let req = connection_attempt.await.unwrap();
 
@@ -215,7 +215,7 @@ mod tests {
     async fn rep_max_connections() {
         let _ = tracing_subscriber::fmt::try_init();
         let mut rep = RepSocket::with_options(Tcp::default(), RepOptions::default().max_clients(1));
-        rep.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        rep.bind("127.0.0.1:0").await.unwrap();
 
         let mut req1 = ReqSocket::new(Tcp::default());
         req1.connect(rep.local_addr().unwrap()).await.unwrap();

--- a/msg-socket/src/sub/driver.rs
+++ b/msg-socket/src/sub/driver.rs
@@ -1,12 +1,14 @@
 use futures::{Future, SinkExt, Stream, StreamExt};
 use rustc_hash::FxHashMap;
-use std::collections::HashSet;
-use std::net::SocketAddr;
-use std::net::{IpAddr, Ipv4Addr};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
+use std::{
+    collections::HashSet,
+    io,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::{sync::mpsc, task::JoinSet};
 use tokio_util::codec::Framed;
@@ -249,17 +251,17 @@ where
                 let ack = conn
                     .next()
                     .await
-                    .ok_or(std::io::Error::new(
-                        std::io::ErrorKind::UnexpectedEof,
+                    .ok_or(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
                         "Connection closed",
                     ))?
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::PermissionDenied, e))?;
+                    .map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e))?;
 
                 if matches!(ack, auth::Message::Ack) {
                     Ok((addr, conn.into_inner()))
                 } else {
-                    Err(std::io::Error::new(
-                        std::io::ErrorKind::PermissionDenied,
+                    Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
                         "Publisher denied connection",
                     )
                     .into())

--- a/msg/benches/pubsub.rs
+++ b/msg/benches/pubsub.rs
@@ -34,10 +34,7 @@ impl<T: Transport + Send + Sync + Unpin + 'static> PairBenchmark<T> {
     fn init(&mut self) {
         // Set up the socket connections
         self.rt.block_on(async {
-            self.publisher
-                .bind("127.0.0.1:0".parse().unwrap())
-                .await
-                .unwrap();
+            self.publisher.bind("127.0.0.1:0").await.unwrap();
 
             let addr = self.publisher.local_addr().unwrap();
             self.subscriber.connect(addr).await.unwrap();

--- a/msg/benches/reqrep.rs
+++ b/msg/benches/reqrep.rs
@@ -36,7 +36,7 @@ impl PairBenchmark {
         let mut rep = self.rep.take().unwrap();
         // setup the socket connections
         self.rt.block_on(async {
-            rep.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+            rep.bind("127.0.0.1:0").await.unwrap();
 
             self.req.connect(rep.local_addr().unwrap()).await.unwrap();
 

--- a/msg/examples/durable.rs
+++ b/msg/examples/durable.rs
@@ -23,7 +23,7 @@ async fn start_rep() {
     // Initialize the reply socket (server side) with a transport
     // and an authenticator.
     let mut rep = RepSocket::new(Tcp::default()).with_auth(Auth);
-    while rep.bind("0.0.0.0:4444".parse().unwrap()).await.is_err() {
+    while rep.bind("0.0.0.0:4444").await.is_err() {
         rep = RepSocket::new(Tcp::default()).with_auth(Auth);
         tracing::warn!("Failed to bind rep socket, retrying...");
         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -76,7 +76,7 @@ async fn main() {
     tokio::spawn(
         async move {
             tracing::info!("Trying to connect to rep socket... This will start the connection process in the background, it won't immediately connect.");
-            req.connect("0.0.0.0:4444".parse().unwrap()).await.unwrap();
+            req.connect("0.0.0.0:4444").await.unwrap();
 
             for i in 0..10 {
                 tracing::info!("Sending request {i}...");

--- a/msg/examples/pubsub.rs
+++ b/msg/examples/pubsub.rs
@@ -31,10 +31,7 @@ async fn main() {
     );
 
     tracing::info!("Setting up the sockets...");
-    pub_socket
-        .bind("127.0.0.1:0".parse().unwrap())
-        .await
-        .unwrap();
+    pub_socket.bind("127.0.0.1:0").await.unwrap();
     let pub_addr = pub_socket.local_addr().unwrap();
 
     tracing::info!("Publisher listening on: {}", pub_addr);

--- a/msg/examples/pubsub_auth.rs
+++ b/msg/examples/pubsub_auth.rs
@@ -45,10 +45,7 @@ async fn main() {
     );
 
     tracing::info!("Setting up the sockets...");
-    pub_socket
-        .bind("127.0.0.1:0".parse().unwrap())
-        .await
-        .unwrap();
+    pub_socket.bind("127.0.0.1:0").await.unwrap();
 
     let pub_addr = pub_socket.local_addr().unwrap();
     tracing::info!("Publisher listening on: {}", pub_addr);

--- a/msg/examples/pubsub_compression.rs
+++ b/msg/examples/pubsub_compression.rs
@@ -21,10 +21,7 @@ async fn main() {
     let mut sub2 = SubSocket::new(Tcp::default());
 
     tracing::info!("Setting up the sockets...");
-    pub_socket
-        .bind("127.0.0.1:0".parse().unwrap())
-        .await
-        .unwrap();
+    pub_socket.bind("127.0.0.1:0").await.unwrap();
 
     let pub_addr = pub_socket.local_addr().unwrap();
     tracing::info!("Publisher listening on: {}", pub_addr);

--- a/msg/examples/quic_vs_tcp.rs
+++ b/msg/examples/quic_vs_tcp.rs
@@ -30,10 +30,7 @@ async fn run_tcp() {
     );
 
     tracing::info!("Setting up the sockets...");
-    pub_socket
-        .bind("127.0.0.1:0".parse().unwrap())
-        .await
-        .unwrap();
+    pub_socket.bind("127.0.0.1:0").await.unwrap();
     let pub_addr = pub_socket.local_addr().unwrap();
 
     tracing::info!("Publisher listening on: {}", pub_addr);
@@ -66,10 +63,7 @@ async fn run_quic() {
     );
 
     tracing::info!("Setting up the sockets...");
-    pub_socket
-        .bind("127.0.0.1:0".parse().unwrap())
-        .await
-        .unwrap();
+    pub_socket.bind("127.0.0.1:0").await.unwrap();
     let pub_addr = pub_socket.local_addr().unwrap();
 
     tracing::info!("Publisher listening on: {}", pub_addr);

--- a/msg/examples/reqrep.rs
+++ b/msg/examples/reqrep.rs
@@ -7,11 +7,11 @@ use msg::{tcp::Tcp, RepSocket, ReqSocket};
 async fn main() {
     // Initialize the reply socket (server side) with a transport
     let mut rep = RepSocket::new(Tcp::default());
-    rep.bind("0.0.0.0:4444".parse().unwrap()).await.unwrap();
+    rep.bind("0.0.0.0:4444").await.unwrap();
 
     // Initialize the request socket (client side) with a transport
     let mut req = ReqSocket::new(Tcp::default());
-    req.connect("0.0.0.0:4444".parse().unwrap()).await.unwrap();
+    req.connect("0.0.0.0:4444").await.unwrap();
 
     tokio::spawn(async move {
         // Receive the request and respond with "world"

--- a/msg/examples/reqrep_auth.rs
+++ b/msg/examples/reqrep_auth.rs
@@ -20,7 +20,7 @@ async fn main() {
     // Initialize the reply socket (server side) with a transport
     // and an authenticator.
     let mut rep = RepSocket::new(Tcp::default()).with_auth(Auth);
-    rep.bind("0.0.0.0:4444".parse().unwrap()).await.unwrap();
+    rep.bind("0.0.0.0:4444").await.unwrap();
 
     // Initialize the request socket (client side) with a transport
     // and an identifier. This will implicitly turn on client authentication.
@@ -29,7 +29,7 @@ async fn main() {
         ReqOptions::default().auth_token(Bytes::from("REQ")),
     );
 
-    req.connect("0.0.0.0:4444".parse().unwrap()).await.unwrap();
+    req.connect("0.0.0.0:4444").await.unwrap();
 
     tokio::spawn(async move {
         // Receive the request and respond with "world"


### PR DESCRIPTION
## Breaking changes

- API interface: `bind` and `connect` socket methods now accept a simple `&str` instead of `SocketAddr`. This does dns resolution in the background as well.

---

- Closes #62 