### PR TITLE
feat: reqrep compression

### DIFF
--- a/book/src/links.md
+++ b/book/src/links.md
@@ -13,6 +13,7 @@
 [new-issue]: https://github.com/chainbound/msg-rs/issues/new
 [license]: https://github.com/chainbound/msg-rs/blob/main/LICENSE
 [contributing]: https://github.com/chainbound/msg-rs/tree/main/CONTRIBUTING.md
+[examples]: https://github.com/chainboudn/msg-rs/tree/main/msg/examples
 
 <!-- Chainbound links -->
 

--- a/book/src/usage/compression.md
+++ b/book/src/usage/compression.md
@@ -6,9 +6,45 @@ MSG-RS supports message compression out of the box, and it is very easy to use.
 Compression is most useful in scenarios where you are sending large messages over the network.
 It can also help reduce the amount of bandwidth used by your application.
 
-In MSG, compression is handled by the socket type.
+In MSG, compression is handled by the socket type:
 
-Here is an example of setting up a pub/sub socket with compression:
+- [Request/Response](#requestresponse)
+- [Publish/Subscribe](#publishsubscribe)
+
+---
+
+## Request/Response
+
+You can also find a complete example in [msg/examples/reqrep_compression.rs][examples].
+
+```rust
+use msg::{compression::GzipCompressor, ReqSocket, RepSocket, Tcp};
+
+#[tokio::main]
+async fn main() {
+    // Initialize the reply socket (server side) with a transport
+    let mut rep = RepSocket::new(Tcp::default())
+            // Enable Gzip compression (compression level 6).
+            .with_compressor(GzipCompressor::new(6));
+
+    rep.bind("0.0.0.0:4444").await.unwrap();
+
+    // Initialize the request socket (client side) with a transport
+    let mut req = ReqSocket::new(Tcp::default())
+            // Enable Gzip compression (compression level 6).
+            // The request and response sockets *don't have to*
+            // use the same compression algorithm or level.
+            .with_compressor(GzipCompressor::new(6));
+
+    req.connect("0.0.0.0:4444").await.unwrap();
+
+    // ...
+}
+```
+
+## Publish/Subscribe
+
+You can also find a complete example in [msg/examples/pubsub_compression.rs][examples].
 
 ```rust
 use msg::{compression::GzipCompressor, PubSocket, SubSocket, Tcp};
@@ -21,13 +57,13 @@ async fn main() {
         .with_compressor(GzipCompressor::new(6));
 
     // Configure the subscribers with options
-    let mut sub1 = SubSocket::new(Tcp::default());
+    let mut sub_socket = SubSocket::new(Tcp::default());
 
     // ...
 }
 ```
 
-By looking at this, you might be wondering: "how does the subscriber know that the
+By looking at this example, you might be wondering: "how does the subscriber know that the
 publisher is compressing messages, if the subscriber is not configured with Gzip compression?"
 
 The answer is that in MSG, compression is defined by the publisher for each message that is sent.

--- a/msg-socket/src/rep/driver.rs
+++ b/msg-socket/src/rep/driver.rs
@@ -19,7 +19,11 @@ use tracing::{debug, error, info, warn};
 
 use crate::{rep::SocketState, AuthResult, Authenticator, PubError, RepOptions, Request};
 use msg_transport::{PeerAddress, Transport};
-use msg_wire::{auth, compression::try_decompress_payload, reqrep};
+use msg_wire::{
+    auth,
+    compression::{try_decompress_payload, Compressor},
+    reqrep,
+};
 
 pub(crate) struct PeerState<T: AsyncRead + AsyncWrite> {
     pending_requests: FuturesUnordered<PendingRequest>,
@@ -28,6 +32,7 @@ pub(crate) struct PeerState<T: AsyncRead + AsyncWrite> {
     egress_queue: VecDeque<reqrep::Message>,
     state: Arc<SocketState>,
     should_flush: bool,
+    compressor: Option<Arc<dyn Compressor>>,
 }
 
 pub(crate) struct RepDriver<T: Transport> {
@@ -44,6 +49,9 @@ pub(crate) struct RepDriver<T: Transport> {
     pub(crate) to_socket: mpsc::Sender<Request>,
     /// Optional connection authenticator.
     pub(crate) auth: Option<Arc<dyn Authenticator>>,
+    /// Optional message compressor. This is shared with the socket to keep
+    /// the API consistent with other socket types (e.g. `PubSocket`)
+    pub(crate) compressor: Option<Arc<dyn Compressor>>,
     /// A set of pending incoming connections, represented by [`Transport::Accept`].
     pub(super) conn_tasks: FuturesUnordered<T::Accept>,
     /// A joinset of authentication tasks.
@@ -94,6 +102,7 @@ where
                                 egress_queue: VecDeque::with_capacity(128),
                                 state: Arc::clone(&this.state),
                                 should_flush: false,
+                                compressor: this.compressor.clone(),
                             }),
                         );
                     }
@@ -216,6 +225,7 @@ where
                     egress_queue: VecDeque::with_capacity(128),
                     state: Arc::clone(&self.state),
                     should_flush: false,
+                    compressor: self.compressor.clone(),
                 }),
             );
         }
@@ -262,11 +272,31 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for PeerState<T> {
             }
 
             // Then we check for completed requests, and push them onto the egress queue.
-            if let Poll::Ready(Some(Some((id, payload)))) =
+            if let Poll::Ready(Some(Some((id, mut payload)))) =
                 this.pending_requests.poll_next_unpin(cx)
             {
-                // TODO: compress the response payload.
-                let compression_type = 0;
+                let mut compression_type = 0;
+                let len_before = payload.len();
+                if let Some(ref compressor) = this.compressor {
+                    match compressor.compress(&payload) {
+                        Ok(compressed) => {
+                            payload = compressed;
+                            compression_type = compressor.compression_type() as u8;
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to compress message: {:?}", e);
+                            continue;
+                        }
+                    }
+
+                    tracing::debug!(
+                        "Compressed message {} from {} to {} bytes",
+                        id,
+                        len_before,
+                        payload.len()
+                    )
+                }
+
                 let msg = reqrep::Message::new(id, compression_type, payload);
                 this.egress_queue.push_back(msg);
 

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -61,11 +61,15 @@ pub(crate) struct SocketState {
     pub(crate) stats: SocketStats,
 }
 
-/// A request received by the socket. It contains the source address, the message,
-/// and a oneshot channel to respond to the request.
+/// A request received by the socket.
 pub struct Request {
+    /// The source address of the request.
     source: SocketAddr,
+    /// The compression type used for the request payload
+    compression_type: u8,
+    /// The oneshot channel to respond to the request.
     response: oneshot::Sender<Bytes>,
+    /// The message payload.
     msg: Bytes,
 }
 

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -25,16 +25,32 @@ pub enum PubError {
     Transport(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
-#[derive(Default)]
 pub struct RepOptions {
     /// The maximum number of concurrent clients.
     max_clients: Option<usize>,
+    min_compress_size: usize,
+}
+
+impl Default for RepOptions {
+    fn default() -> Self {
+        Self {
+            max_clients: None,
+            min_compress_size: 8192,
+        }
+    }
 }
 
 impl RepOptions {
     /// Sets the number of maximum concurrent clients.
     pub fn max_clients(mut self, max_clients: usize) -> Self {
         self.max_clients = Some(max_clients);
+        self
+    }
+
+    /// Sets the minimum payload size for compression.
+    /// If the payload is smaller than this value, it will not be compressed.
+    pub fn min_compress_size(mut self, min_compress_size: usize) -> Self {
+        self.min_compress_size = min_compress_size;
         self
     }
 }

--- a/msg-socket/src/req/driver.rs
+++ b/msg-socket/src/req/driver.rs
@@ -4,6 +4,7 @@ use msg_transport::Transport;
 use rustc_hash::FxHashMap;
 use std::{
     collections::VecDeque,
+    io,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
@@ -11,10 +12,13 @@ use std::{
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::codec::Framed;
 
-use crate::req::SocketState;
+use crate::{req::SocketState, ReqMessage};
 
 use super::{Command, ReqError, ReqOptions};
-use msg_wire::reqrep;
+use msg_wire::{
+    compression::{try_decompress_payload, Compressor},
+    reqrep,
+};
 use std::time::Instant;
 use tokio::time::Interval;
 
@@ -42,6 +46,9 @@ pub(crate) struct ReqDriver<T: Transport> {
     pub(crate) flush_interval: Option<tokio::time::Interval>,
     /// Whether or not the connection should be flushed
     pub(crate) should_flush: bool,
+    /// Optional message compressor. This is shared with the socket to keep
+    /// the API consistent with other socket types (e.g. `PubSocket`)
+    pub(crate) compressor: Option<Arc<dyn Compressor>>,
 }
 
 /// A pending request that is waiting for a response.
@@ -57,7 +64,22 @@ impl<T: Transport> ReqDriver<T> {
         if let Some(pending) = self.pending_requests.remove(&msg.id()) {
             let rtt = pending.start.elapsed().as_micros() as usize;
             let size = msg.size();
-            let _ = pending.sender.send(Ok(msg.into_payload()));
+            let compression_type = msg.header().compression_type();
+            let mut payload = msg.into_payload();
+
+            // decompress the response
+            match try_decompress_payload(compression_type, payload) {
+                Ok(decompressed) => payload = decompressed,
+                Err(e) => {
+                    tracing::error!("Failed to decompress response payload: {:?}", e);
+                    let _ = pending.sender.send(Err(ReqError::Wire(reqrep::Error::Io(
+                        io::Error::new(io::ErrorKind::Other, "Failed to decompress response"),
+                    ))));
+                    return;
+                }
+            }
+
+            let _ = pending.sender.send(Ok(payload));
 
             // Update stats
             self.socket_state.stats.update_rtt(rtt);
@@ -178,7 +200,25 @@ where
                 Poll::Ready(Some(Command::Send { message, response })) => {
                     // Queue the message for sending
                     let start = std::time::Instant::now();
-                    let msg = message.into_wire(this.id_counter);
+
+                    let mut msg = ReqMessage::new(message);
+
+                    let len_before = msg.payload().len();
+                    if len_before > this.options.min_compress_size {
+                        if let Some(ref compressor) = this.compressor {
+                            if let Err(e) = msg.compress(compressor.as_ref()) {
+                                tracing::error!("Failed to compress message: {:?}", e);
+                            }
+
+                            tracing::debug!(
+                                "Compressed message from {} to {} bytes",
+                                len_before,
+                                msg.payload().len()
+                            );
+                        }
+                    }
+
+                    let msg = msg.into_wire(this.id_counter);
                     let msg_id = msg.id();
                     this.id_counter = this.id_counter.wrapping_add(1);
                     this.egress_queue.push_back(msg);

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -36,7 +36,7 @@ pub enum ReqError {
 
 pub enum Command {
     Send {
-        message: ReqMessage,
+        message: Bytes,
         response: oneshot::Sender<Result<Bytes, ReqError>>,
     },
 }

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -1,20 +1,23 @@
 use bytes::Bytes;
 use futures::SinkExt;
+use msg_wire::compression::Compressor;
 use rustc_hash::FxHashMap;
 use std::{collections::VecDeque, io, sync::Arc, time::Duration};
 use tokio::net::{lookup_host, ToSocketAddrs};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
+use tracing::debug;
 
 use msg_transport::Transport;
 use msg_wire::{auth, reqrep};
 
 use super::{Command, ReqDriver, ReqError, ReqOptions, DEFAULT_BUFFER_SIZE};
 use crate::backoff::ExponentialBackoff;
+use crate::ReqMessage;
 use crate::{req::stats::SocketStats, req::SocketState};
 
-#[derive(Debug)]
+/// The request socket.
 pub struct ReqSocket<T: Transport> {
     /// Command channel to the backend task.
     to_driver: Option<mpsc::Sender<Command>>,
@@ -24,6 +27,10 @@ pub struct ReqSocket<T: Transport> {
     options: Arc<ReqOptions>,
     /// Socket state. This is shared with the backend task.
     state: Arc<SocketState>,
+    /// Optional message compressor.
+    // NOTE: for now we're using dynamic dispatch, since using generics here
+    // complicates the API a lot. We can always change this later for perf reasons.
+    compressor: Option<Arc<dyn Compressor>>,
 }
 
 impl<T> ReqSocket<T>
@@ -40,7 +47,14 @@ where
             transport,
             options: Arc::new(options),
             state: Arc::new(SocketState::default()),
+            compressor: None,
         }
+    }
+
+    /// Sets the message compressor for this socket.
+    pub fn with_compressor<C: Compressor + 'static>(mut self, compressor: C) -> Self {
+        self.compressor = Some(Arc::new(compressor));
+        self
     }
 
     pub fn stats(&self) -> &SocketStats {
@@ -50,11 +64,26 @@ where
     pub async fn request(&self, message: Bytes) -> Result<Bytes, ReqError> {
         let (response_tx, response_rx) = oneshot::channel();
 
+        let mut msg = ReqMessage::new(message);
+
+        let len_before = msg.payload().len();
+        if len_before > self.options.min_compress_size {
+            if let Some(ref compressor) = self.compressor {
+                msg.compress(compressor.as_ref())?;
+
+                debug!(
+                    "Compressed message from {} to {} bytes",
+                    len_before,
+                    msg.payload().len()
+                );
+            }
+        }
+
         self.to_driver
             .as_ref()
             .ok_or(ReqError::SocketClosed)?
             .send(Command::Send {
-                message,
+                message: msg,
                 response: response_tx,
             })
             .await

--- a/msg-wire/src/compression/mod.rs
+++ b/msg-wire/src/compression/mod.rs
@@ -58,10 +58,12 @@ pub trait Decompressor: Send + Sync + Unpin + 'static {
 /// - If the decompression fails
 pub fn try_decompress_payload(compression_type: u8, data: Bytes) -> Result<Bytes, io::Error> {
     match CompressionType::try_from(compression_type) {
-        Ok(CompressionType::None) => Ok(data),
-        Ok(CompressionType::Gzip) => GzipDecompressor.decompress(data.as_ref()),
-        Ok(CompressionType::Zstd) => ZstdDecompressor.decompress(data.as_ref()),
-        Ok(CompressionType::Snappy) => SnappyDecompressor.decompress(data.as_ref()),
+        Ok(supported_compression_type) => match supported_compression_type {
+            CompressionType::None => Ok(data),
+            CompressionType::Gzip => GzipDecompressor.decompress(data.as_ref()),
+            CompressionType::Zstd => ZstdDecompressor.decompress(data.as_ref()),
+            CompressionType::Snappy => SnappyDecompressor.decompress(data.as_ref()),
+        },
         Err(unsupported_compression_type) => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("unsupported compression type: {unsupported_compression_type}"),

--- a/msg-wire/src/reqrep.rs
+++ b/msg-wire/src/reqrep.rs
@@ -22,10 +22,11 @@ pub struct Message {
 
 impl Message {
     #[inline]
-    pub fn new(id: u32, payload: Bytes) -> Self {
+    pub fn new(id: u32, compression_type: u8, payload: Bytes) -> Self {
         Self {
             header: Header {
                 id,
+                compression_type,
                 size: payload.len() as u32,
             },
             payload,
@@ -44,7 +45,12 @@ impl Message {
 
     #[inline]
     pub fn size(&self) -> usize {
-        Header::len() + self.payload_size() as usize
+        self.header.len() + self.payload_size() as usize
+    }
+
+    #[inline]
+    pub fn header(&self) -> &Header {
+        &self.header
     }
 
     #[inline]
@@ -60,6 +66,8 @@ impl Message {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Header {
+    /// The compression type.
+    pub(crate) compression_type: u8,
     /// The message ID.
     pub(crate) id: u32,
     /// The size of the message. Max 4GiB.
@@ -69,8 +77,20 @@ pub struct Header {
 impl Header {
     /// Returns the length of the header in bytes.
     #[inline]
-    pub fn len() -> usize {
-        8
+    pub fn len(&self) -> usize {
+        4 + // id
+        4 + // size
+        1 // compression type
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub fn compression_type(&self) -> u8 {
+        self.compression_type
     }
 }
 
@@ -101,25 +121,38 @@ impl Decoder for Codec {
         loop {
             match self.state {
                 State::Header => {
+                    let mut cursor = 0;
+
                     if src.is_empty() {
                         return Ok(None);
                     }
 
                     // Wire ID check (without advancing the cursor)
-                    let wire_id = u8::from_be_bytes([src[0]]);
+                    let wire_id = u8::from_be_bytes([src[cursor]]);
+                    cursor += 1;
                     if wire_id != WIRE_ID {
                         return Err(Error::WireId(wire_id));
                     }
 
-                    if src.len() < Header::len() {
+                    // The src is too small to read the compression type
+                    if src.len() < cursor + 1 {
+                        return Ok(None);
+                    }
+
+                    let compression_type = u8::from_be_bytes([src[cursor]]);
+
+                    cursor += 1;
+
+                    if src.len() < cursor + 8 {
                         return Ok(None);
                     }
 
                     // Only advance when we know we have enough bytes
-                    src.advance(1);
+                    src.advance(cursor);
 
                     // Construct the header
                     let header = Header {
+                        compression_type,
                         id: src.get_u32(),
                         size: src.get_u32(),
                     };
@@ -149,9 +182,10 @@ impl Encoder<Message> for Codec {
     type Error = Error;
 
     fn encode(&mut self, item: Message, dst: &mut bytes::BytesMut) -> Result<(), Self::Error> {
-        dst.reserve(1 + 8 + item.payload_size() as usize);
+        dst.reserve(1 + item.header.len() + item.payload_size() as usize);
 
         dst.put_u8(WIRE_ID);
+        dst.put_u8(item.header.compression_type);
         dst.put_u32(item.header.id);
         dst.put_u32(item.header.size);
         dst.put(item.payload);

--- a/msg/examples/reqrep_compression.rs
+++ b/msg/examples/reqrep_compression.rs
@@ -1,0 +1,33 @@
+use bytes::Bytes;
+use msg_socket::ReqOptions;
+use msg_wire::compression::GzipCompressor;
+use tokio_stream::StreamExt;
+
+use msg::{tcp::Tcp, RepSocket, ReqSocket};
+
+#[tokio::main]
+async fn main() {
+    // Initialize the reply socket (server side) with a transport
+    let mut rep = RepSocket::new(Tcp::default());
+    rep.bind("0.0.0.0:4444").await.unwrap();
+
+    // Initialize the request socket (client side) with a transport
+    let mut req =
+        ReqSocket::with_options(Tcp::default(), ReqOptions::default().min_compress_size(0))
+            // Enable Gzip compression (compression level 6)
+            .with_compressor(GzipCompressor::new(6));
+
+    req.connect("0.0.0.0:4444").await.unwrap();
+
+    tokio::spawn(async move {
+        // Receive the request and respond with "world"
+        // RepSocket implements `Stream`
+        let req = rep.next().await.unwrap();
+        println!("Message: {:?}", req.msg());
+
+        req.respond(Bytes::from("world")).unwrap();
+    });
+
+    let res: Bytes = req.request(Bytes::from("hello")).await.unwrap();
+    println!("Response: {:?}", res);
+}

--- a/msg/examples/reqrep_compression.rs
+++ b/msg/examples/reqrep_compression.rs
@@ -8,7 +8,7 @@ use msg::{tcp::Tcp, RepSocket, ReqSocket};
 #[tokio::main]
 async fn main() {
     // Initialize the reply socket (server side) with a transport
-    // and a minimum compresion size of 0 bytes for responses
+    // and a minimum compresion size of 0 bytes to compress all responses
     let mut rep =
         RepSocket::with_options(Tcp::default(), RepOptions::default().min_compress_size(0))
             // Enable Gzip compression (compression level 6)
@@ -16,7 +16,7 @@ async fn main() {
     rep.bind("0.0.0.0:4444").await.unwrap();
 
     // Initialize the request socket (client side) with a transport
-    // and a minimum compresion size of 0 bytes for requests
+    // and a minimum compresion size of 0 bytes to compress all requests
     let mut req =
         ReqSocket::with_options(Tcp::default(), ReqOptions::default().min_compress_size(0))
             // Enable Gzip compression (compression level 6).


### PR DESCRIPTION
## Req/Rep Compression

```[tasklist]
### Tasks
- [x] Added example in `examples/reqrep_compression.rs`
- [x] Added the `ReqMessage` type
- [x] Refactored the `try_compress` method to work on any kind of message payload
- [x] Added support for de-compression of requests
- [x] Added support for de-compression of responses
- [x] Updated mdbook docs
- [x] Added test with reqrep compression
``` 

---

- closes #56 
