### PR TITLE
feat: `ConnectionState` abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ version = "0.1.1"
 dependencies = [
  "futures",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/msg-common/Cargo.toml
+++ b/msg-common/Cargo.toml
@@ -15,3 +15,4 @@ repository.workspace = true
 [dependencies]
 futures.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true

--- a/msg-socket/src/connection/backoff.rs
+++ b/msg-socket/src/connection/backoff.rs
@@ -2,6 +2,13 @@ use futures::{FutureExt, Stream};
 use std::{pin::Pin, task::Poll, time::Duration};
 use tokio::time::sleep;
 
+/// Helper trait alias for backoff streams.
+/// We define any stream that yields `Duration`s as a backoff
+pub trait Backoff: Stream<Item = Duration> + Unpin {}
+
+/// Blanket implementation of `Backoff` for any stream that yields `Duration`s.
+impl<T> Backoff for T where T: Stream<Item = Duration> + Unpin {}
+
 /// A stream that yields exponentially increasing backoff durations.
 pub struct ExponentialBackoff {
     /// Current number of retries.

--- a/msg-socket/src/connection/mod.rs
+++ b/msg-socket/src/connection/mod.rs
@@ -1,0 +1,5 @@
+pub mod state;
+pub use state::ConnectionState;
+
+pub mod backoff;
+pub use backoff::{Backoff, ExponentialBackoff};

--- a/msg-socket/src/connection/state.rs
+++ b/msg-socket/src/connection/state.rs
@@ -1,0 +1,34 @@
+use std::net::SocketAddr;
+
+use super::Backoff;
+
+/// Abstraction to represent the state of a connection.
+///
+/// * `C` is the channel type, which is used to send and receive generic messages.
+/// * `B` is the backoff type, used to control the backoff state for inactive connections.
+pub enum ConnectionState<C, B> {
+    Active {
+        /// Channel to control the underlying connection. This is used to send
+        /// and receive any kind of message in any direction.
+        channel: C,
+    },
+    Inactive {
+        addr: SocketAddr,
+        /// The current backoff state for inactive connections.
+        backoff: B,
+    },
+}
+
+impl<C, B: Backoff> ConnectionState<C, B> {
+    /// Returns `true` if the connection is active.
+    #[allow(unused)]
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Active { .. })
+    }
+
+    /// Returns `true` if the connection is inactive.
+    #[allow(unused)]
+    pub fn is_inactive(&self) -> bool {
+        matches!(self, Self::Inactive { .. })
+    }
+}

--- a/msg-socket/src/lib.rs
+++ b/msg-socket/src/lib.rs
@@ -7,7 +7,7 @@ mod rep;
 mod req;
 mod sub;
 
-mod backoff;
+mod connection;
 
 use bytes::Bytes;
 pub use pubs::{PubError, PubOptions, PubSocket};

--- a/msg-socket/src/pub/socket.rs
+++ b/msg-socket/src/pub/socket.rs
@@ -114,7 +114,6 @@ where
         tokio::spawn(backend);
 
         self.local_addr = Some(local_addr);
-        // self.to_driver = Some(to_driver);
         self.to_sessions_bcast = Some(to_sessions_bcast);
 
         Ok(())

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -237,13 +237,15 @@ mod tests {
         let _ = tracing_subscriber::fmt::try_init();
         let mut rep = RepSocket::with_options(Tcp::default(), RepOptions::default().max_clients(1));
         rep.bind("127.0.0.1:0").await.unwrap();
+        let addr = rep.local_addr().unwrap();
 
         let mut req1 = ReqSocket::new(Tcp::default());
-        req1.connect(rep.local_addr().unwrap()).await.unwrap();
+        req1.connect(addr).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert_eq!(rep.stats().active_clients(), 1);
 
         let mut req2 = ReqSocket::new(Tcp::default());
-        req2.connect(rep.local_addr().unwrap()).await.unwrap();
-
+        req2.connect(addr).await.unwrap();
         tokio::time::sleep(Duration::from_secs(1)).await;
         assert_eq!(rep.stats().active_clients(), 1);
     }

--- a/msg-socket/src/req/driver.rs
+++ b/msg-socket/src/req/driver.rs
@@ -340,10 +340,7 @@ where
                     continue;
                 }
                 Poll::Ready(None) => {
-                    debug!(
-                        "Connection to {:? } closed, shutting down driver",
-                        this.addr
-                    );
+                    debug!("Connection to {:?} closed, shutting down driver", this.addr);
 
                     return Poll::Ready(());
                 }
@@ -366,7 +363,6 @@ where
                             error!("Failed to send message to socket: {:?}", e);
 
                             // set the connection to inactive, so that it will be re-tried
-                            dbg!("2222");
                             this.reset_connection();
                         }
                     }

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -36,7 +36,7 @@ pub enum ReqError {
 
 pub enum Command {
     Send {
-        message: Bytes,
+        message: ReqMessage,
         response: oneshot::Sender<Result<Bytes, ReqError>>,
     },
 }

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -13,6 +13,7 @@ use msg_wire::{auth, reqrep};
 
 use super::{Command, ReqDriver, ReqError, ReqOptions, DEFAULT_BUFFER_SIZE};
 use crate::backoff::ExponentialBackoff;
+use crate::ReqMessage;
 use crate::{req::stats::SocketStats, req::SocketState};
 
 /// The request socket.
@@ -62,11 +63,13 @@ where
     pub async fn request(&self, message: Bytes) -> Result<Bytes, ReqError> {
         let (response_tx, response_rx) = oneshot::channel();
 
+        let msg = ReqMessage::new(message);
+
         self.to_driver
             .as_ref()
             .ok_or(ReqError::SocketClosed)?
             .send(Command::Send {
-                message,
+                message: msg,
                 response: response_tx,
             })
             .await

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -100,9 +100,7 @@ where
             backoff: ExponentialBackoff::new(Duration::from_millis(20), 16),
         };
 
-        let timeout_check_interval = tokio::time::interval(Duration::from_millis(
-            self.options.timeout.as_millis() as u64 / 10,
-        ));
+        let timeout_check_interval = tokio::time::interval(self.options.timeout / 10);
 
         let flush_interval = self.options.flush_interval.map(tokio::time::interval);
 

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -93,8 +93,8 @@ where
             .take()
             .expect("Transport has been moved already");
 
-        // We initialize the connection as inactive, and let it be activated by the backend task
-        // as soon as the driver is spawned.
+        // We initialize the connection as inactive, and let it be activated
+        // by the backend task as soon as the driver is spawned.
         let conn_state = ConnectionState::Inactive {
             addr: endpoint,
             backoff: ExponentialBackoff::new(Duration::from_millis(20), 16),
@@ -112,6 +112,7 @@ where
 
         // Create the socket backend
         let driver: ReqDriver<T> = ReqDriver {
+            addr: endpoint,
             options: Arc::clone(&self.options),
             socket_state: Arc::clone(&self.state),
             id_counter: 0,

--- a/msg-socket/src/sub/stream.rs
+++ b/msg-socket/src/sub/stream.rs
@@ -18,11 +18,6 @@ pub(super) struct PublisherStream<Io> {
 }
 
 impl<Io: AsyncRead + AsyncWrite + Unpin> PublisherStream<Io> {
-    /// Cretes a new publisher stream from the given framed connection.
-    pub fn new(conn: Framed<Io, pubsub::Codec>) -> Self {
-        Self { conn, flush: false }
-    }
-
     /// Queues a message to be sent to the publisher. If the connection
     /// is ready, this will register the waker
     /// and flush on the next poll.
@@ -44,6 +39,12 @@ impl<Io: AsyncRead + AsyncWrite + Unpin> PublisherStream<Io> {
         cx.waker().wake_by_ref();
 
         Poll::Ready(Ok(()))
+    }
+}
+
+impl<Io: AsyncRead + AsyncWrite + Unpin> From<Framed<Io, pubsub::Codec>> for PublisherStream<Io> {
+    fn from(conn: Framed<Io, pubsub::Codec>) -> Self {
+        Self { conn, flush: false }
     }
 }
 

--- a/msg/examples/reqrep.rs
+++ b/msg/examples/reqrep.rs
@@ -22,6 +22,15 @@ async fn main() {
         req.respond(Bytes::from("world")).unwrap();
     });
 
-    let res: Bytes = req.request(Bytes::from("hello")).await.unwrap();
+    let res: Bytes = req.request(Bytes::from("helloooo!")).await.unwrap();
     println!("Response: {:?}", res);
+
+    // Access the socket statistics
+    let stats = req.stats();
+    println!(
+        "Sent: {}B, Received: {}B | time: {}μs",
+        stats.bytes_tx(),
+        stats.bytes_rx(),
+        stats.rtt()
+    );
 }


### PR DESCRIPTION
This PR introduces the `ConnectionState` enum to replace the `PublisherState` in pubsub and generalize over reqrep for handling of backoff and inactive connection strategies.

## Tasks

- [x] Refactored the `msg_socket/backoff` module in `msg_socket/connection` with `backoff` and `state` inside.
- [x] Added usage of `ConnectionState` in the sub driver poll impl
- [x] Added usage of `ConnectionState` in the req driver poll impl
- [x] Updated the book (if necessary)

---

- closes #60