### PR TITLE
feat: lz4 compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912b45c753ff5f7f5208307e8ace7d2a2e30d024e26d3509f3dce546c044ce15"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +795,7 @@ version = "0.1.1"
 dependencies = [
  "bytes",
  "flate2",
+ "lz4_flex",
  "msg-common",
  "snap",
  "thiserror",
@@ -1536,6 +1546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +1799,16 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,6 @@ quinn = "0.10"
 # rustls needs to be the same version as the one used by quinn
 rustls = { version = "0.21", features = ["quic", "dangerous_configuration"] }
 rcgen = "0.12"
-flate2 = "1"
-zstd = "0.13"
-snap = "1"
 
 # benchmarking & profiling
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/book/src/usage/compression.md
+++ b/book/src/usage/compression.md
@@ -77,6 +77,7 @@ with the default compression methods:
 - Gzip
 - Zstd
 - Snappy
+- LZ4
 
 If you wish to use a custom compression algorithm, this is not exposed with a public API yet.
 If you need this, please [open an issue][new-issue] on Github and we will prioritize it!

--- a/msg-socket/src/lib.rs
+++ b/msg-socket/src/lib.rs
@@ -8,6 +8,7 @@ mod req;
 mod sub;
 
 mod connection;
+pub use connection::*;
 
 use bytes::Bytes;
 pub use pubs::{PubError, PubOptions, PubSocket};

--- a/msg-socket/src/req/driver.rs
+++ b/msg-socket/src/req/driver.rs
@@ -17,12 +17,9 @@ use tokio::{
 use tokio_util::codec::Framed;
 use tracing::{debug, error, trace};
 
-use crate::{
-    connection::{ConnectionState, ExponentialBackoff},
-    req::SocketState,
-};
-
 use super::{Command, ReqError, ReqOptions};
+use crate::{req::SocketState, ConnectionState, ExponentialBackoff};
+
 use msg_transport::Transport;
 use msg_wire::{
     auth,

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -8,9 +8,10 @@ use tokio::sync::{mpsc, oneshot};
 use msg_transport::Transport;
 
 use super::{Command, ReqDriver, ReqError, ReqOptions, DEFAULT_BUFFER_SIZE};
-use crate::connection::{ConnectionState, ExponentialBackoff};
-use crate::ReqMessage;
-use crate::{req::stats::SocketStats, req::SocketState};
+use crate::{
+    req::{stats::SocketStats, SocketState},
+    ConnectionState, ExponentialBackoff, ReqMessage,
+};
 
 /// The request socket.
 pub struct ReqSocket<T: Transport> {

--- a/msg-socket/src/sub/driver.rs
+++ b/msg-socket/src/sub/driver.rs
@@ -12,14 +12,13 @@ use tokio::sync::mpsc::{self, error::TrySendError};
 use tokio_util::codec::Framed;
 use tracing::{debug, error, info, warn};
 
-use crate::connection::{ConnectionState, ExponentialBackoff};
-
 use super::session::SessionCommand;
 use super::{
     session::PublisherSession,
     stream::{PublisherStream, TopicMessage},
     Command, PubMessage, SocketState, SubOptions,
 };
+use crate::{ConnectionState, ExponentialBackoff};
 
 use msg_common::{channel, task::JoinMap, Channel};
 use msg_transport::Transport;

--- a/msg-wire/Cargo.toml
+++ b/msg-wire/Cargo.toml
@@ -17,6 +17,8 @@ bytes.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
-flate2.workspace = true
-zstd.workspace = true
-snap.workspace = true
+
+flate2 = "1"
+zstd = "0.13"
+snap = "1"
+lz4_flex = "0.11"

--- a/msg-wire/src/compression/lz4.rs
+++ b/msg-wire/src/compression/lz4.rs
@@ -1,0 +1,39 @@
+use bytes::Bytes;
+use lz4_flex::{compress, decompress};
+use std::io;
+
+use super::{CompressionType, Compressor, Decompressor};
+
+/// A compressor that uses the LZ4 algorithm.
+#[derive(Default)]
+pub struct Lz4Compressor;
+
+impl Compressor for Lz4Compressor {
+    fn compression_type(&self) -> CompressionType {
+        CompressionType::Lz4
+    }
+
+    fn compress(&self, data: &[u8]) -> Result<Bytes, io::Error> {
+        let bytes = compress(data);
+
+        Ok(Bytes::from(bytes))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Lz4Decompressor;
+
+impl Decompressor for Lz4Decompressor {
+    fn decompress(&self, data: &[u8]) -> Result<Bytes, io::Error> {
+        // Usually the Lz4 compression ratio is 2.1x. So 4x should be plenty.
+        let min_uncompressed_size = data.len() * 4;
+        let bytes = decompress(data, min_uncompressed_size).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Lz4 decompression failed: {}", e),
+            )
+        })?;
+
+        Ok(Bytes::from(bytes))
+    }
+}


### PR DESCRIPTION
LZ4 is even faster than Snappy while keeping the same compression ratio. Very impressive!


Mainnet Capella beacon block compression & decompression test results:

```text
uncompressed data size: 287038 bytes
gzip compression shrank the data by 334.39% in 4.06275ms
zstd compression shrank the data by 389.28% in 2.413542ms
snappy compression shrank the data by 202.82% in 454.625µs
lz4 compression shrank the data by 199.92% in 333.125µs
------
gzip decompression took 849.875µs
zstd decompression took 405.666µs
snappy decompression took 152.25µs
lz4 decompression took 128.833µs
```

### Additional changes

- chore: moved compression-related crates to msg-wire instead of workspace manifest
- chore: forgot to export the `connection` module in lib.rs, made imports cleaner.