### PR TITLE
chore: small refactor

### DIFF
--- a/msg-common/Cargo.toml
+++ b/msg-common/Cargo.toml
@@ -10,8 +10,6 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 futures.workspace = true
 tokio.workspace = true

--- a/msg-common/src/channel.rs
+++ b/msg-common/src/channel.rs
@@ -104,11 +104,11 @@ impl<S: Send + 'static, R> Channel<S, R> {
     ///
     /// This method returns:
     ///
-    ///  * `Poll::Pending` if no messages are available but the channel is not
-    ///    closed, or if a spurious failure happens.
+    ///  * `Poll::Pending` if no messages are available but the channel is not closed, or if a
+    ///    spurious failure happens.
     ///  * `Poll::Ready(Some(message))` if a message is available.
-    ///  * `Poll::Ready(None)` if the channel has been closed and all messages
-    ///    sent before it was closed have been received.
+    ///  * `Poll::Ready(None)` if the channel has been closed and all messages sent before it was
+    ///    closed have been received.
     ///
     /// When the method returns `Poll::Pending`, the `Waker` in the provided
     /// `Context` is scheduled to receive a wakeup when a message is sent on any

--- a/msg-common/src/channel.rs
+++ b/msg-common/src/channel.rs
@@ -1,0 +1,155 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{Sink, SinkExt, Stream};
+use tokio::sync::mpsc::{
+    self,
+    error::{TryRecvError, TrySendError},
+    Receiver,
+};
+use tokio_util::sync::{PollSendError, PollSender};
+
+/// A bounded, bi-directional channel for sending and receiving messages.
+/// Relies on Tokio's [`mpsc`] channel.
+///
+/// Channel also implements the [`Stream`] and [`Sink`] traits for convenience.
+pub struct Channel<S, R> {
+    tx: PollSender<S>,
+    rx: Receiver<R>,
+}
+
+/// Creates a new channel with the given buffer size. This will return a tuple of
+/// 2 [`Channel`]s, both of which can be used to send and receive messages.
+///
+/// It works with 2 generic types, `S` and `R`, which represent the types of
+/// messages that can be sent and received, respectively. The first channel in
+/// the tuple can be used to send messages of type `S` and receive messages of
+/// type `R`. The second channel can be used to send messages of type `R` and
+/// receive messages of type `S`.
+pub fn channel<S, R>(tx_buffer: usize, rx_buffer: usize) -> (Channel<S, R>, Channel<R, S>)
+where
+    S: Send,
+    R: Send,
+{
+    let (tx1, rx1) = mpsc::channel(tx_buffer);
+    let (tx2, rx2) = mpsc::channel(rx_buffer);
+
+    let tx1 = PollSender::new(tx1);
+    let tx2 = PollSender::new(tx2);
+
+    (Channel { tx: tx1, rx: rx2 }, Channel { tx: tx2, rx: rx1 })
+}
+
+impl<S: Send + 'static, R> Channel<S, R> {
+    /// Sends a value, waiting until there is capacity.
+    ///
+    /// A successful send occurs when it is determined that the other end of the
+    /// channel has not hung up already. An unsuccessful send would be one where
+    /// the corresponding receiver has already been closed. Note that a return
+    /// value of `Err` means that the data will never be received, but a return
+    /// value of `Ok` does not mean that the data will be received. It is
+    /// possible for the corresponding receiver to hang up immediately after
+    /// this function returns `Ok`.
+    pub async fn send(&mut self, msg: S) -> Result<(), PollSendError<S>> {
+        self.tx.send(msg).await
+    }
+
+    /// Attempts to immediately send a message on this [`Sender`]
+    ///
+    /// This method differs from [`send`] by returning immediately if the channel's
+    /// buffer is full or no receiver is waiting to acquire some data. Compared
+    /// with [`send`], this function has two failure cases instead of one (one for
+    /// disconnection, one for a full buffer).
+    pub fn try_send(&mut self, msg: S) -> Result<(), TrySendError<S>> {
+        if let Some(tx) = self.tx.get_ref() {
+            tx.try_send(msg)
+        } else {
+            Err(TrySendError::Closed(msg))
+        }
+    }
+
+    /// Receives the next value for this receiver.
+    ///
+    /// This method returns `None` if the channel has been closed and there are
+    /// no remaining messages in the channel's buffer. This indicates that no
+    /// further values can ever be received from this `Receiver`. The channel is
+    /// closed when all senders have been dropped, or when [`close`] is called.
+    ///
+    /// If there are no messages in the channel's buffer, but the channel has
+    /// not yet been closed, this method will sleep until a message is sent or
+    /// the channel is closed.  Note that if [`close`] is called, but there are
+    /// still outstanding [`Permits`] from before it was closed, the channel is
+    /// not considered closed by `recv` until the permits are released.
+    pub async fn recv(&mut self) -> Option<R> {
+        self.rx.recv().await
+    }
+
+    /// Tries to receive the next value for this receiver.
+    ///
+    /// This method returns the [`Empty`](TryRecvError::Empty) error if the channel is currently
+    /// empty, but there are still outstanding [senders] or [permits].
+    ///
+    /// This method returns the [`Disconnected`](TryRecvError::Disconnected) error if the channel is
+    /// currently empty, and there are no outstanding [senders] or [permits].
+    ///
+    /// Unlike the [`poll_recv`](Self::poll_recv) method, this method will never return an
+    /// [`Empty`](TryRecvError::Empty) error spuriously.
+    pub fn try_recv(&mut self) -> Result<R, TryRecvError> {
+        self.rx.try_recv()
+    }
+
+    /// Polls to receive the next message on this channel.
+    ///
+    /// This method returns:
+    ///
+    ///  * `Poll::Pending` if no messages are available but the channel is not
+    ///    closed, or if a spurious failure happens.
+    ///  * `Poll::Ready(Some(message))` if a message is available.
+    ///  * `Poll::Ready(None)` if the channel has been closed and all messages
+    ///    sent before it was closed have been received.
+    ///
+    /// When the method returns `Poll::Pending`, the `Waker` in the provided
+    /// `Context` is scheduled to receive a wakeup when a message is sent on any
+    /// receiver, or when the channel is closed.  Note that on multiple calls to
+    /// `poll_recv`, only the `Waker` from the `Context` passed to the most
+    /// recent call is scheduled to receive a wakeup.
+    ///
+    /// If this method returns `Poll::Pending` due to a spurious failure, then
+    /// the `Waker` will be notified when the situation causing the spurious
+    /// failure has been resolved. Note that receiving such a wakeup does not
+    /// guarantee that the next call will succeed — it could fail with another
+    /// spurious failure.
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<R>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+impl<S, R> Stream for Channel<S, R> {
+    type Item = R;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+impl<S: Send + 'static, R> Sink<S> for Channel<S, R> {
+    type Error = PollSendError<S>;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.tx.poll_ready_unpin(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: S) -> Result<(), Self::Error> {
+        self.tx.start_send_unpin(item)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.tx.poll_flush_unpin(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.tx.poll_close_unpin(cx)
+    }
+}

--- a/msg-common/src/lib.rs
+++ b/msg-common/src/lib.rs
@@ -17,10 +17,7 @@ pub use task::JoinMap;
 /// Returns the current UNIX timestamp in microseconds.
 #[inline]
 pub fn unix_micros() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_micros() as u64
+    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_micros() as u64
 }
 
 /// Wraps the given error in a boxed future.

--- a/msg-common/src/lib.rs
+++ b/msg-common/src/lib.rs
@@ -1,22 +1,18 @@
+//! Common utilities and types for msg-rs.
+
 #![doc(issue_tracker_base_url = "https://github.com/chainbound/msg-rs/issues/")]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
-    time::SystemTime,
-};
+use std::time::SystemTime;
 
-use futures::{future::BoxFuture, Sink, SinkExt, Stream};
-use tokio::sync::mpsc::{
-    self,
-    error::{TryRecvError, TrySendError},
-    Receiver,
-};
-use tokio_util::sync::{PollSendError, PollSender};
+use futures::future::BoxFuture;
 
-pub mod task;
+mod channel;
+pub use channel::{channel, Channel};
+
+mod task;
+pub use task::JoinMap;
 
 /// Returns the current UNIX timestamp in microseconds.
 #[inline]
@@ -39,147 +35,4 @@ pub mod constants {
     pub const KiB: u32 = 1024;
     pub const MiB: u32 = 1024 * KiB;
     pub const GiB: u32 = 1024 * MiB;
-}
-
-/// A bounded, bi-directional channel for sending and receiving messages.
-/// Relies on Tokio's [`mpsc`] channel.
-///
-/// Channel also implements the [`Stream`] and [`Sink`] traits for convenience.
-pub struct Channel<S, R> {
-    tx: PollSender<S>,
-    rx: Receiver<R>,
-}
-
-/// Creates a new channel with the given buffer size. This will return a tuple of
-/// 2 [`Channel`]s, both of which can be used to send and receive messages.
-///
-/// It works with 2 generic types, `S` and `R`, which represent the types of
-/// messages that can be sent and received, respectively. The first channel in
-/// the tuple can be used to send messages of type `S` and receive messages of
-/// type `R`. The second channel can be used to send messages of type `R` and
-/// receive messages of type `S`.
-pub fn channel<S, R>(tx_buffer: usize, rx_buffer: usize) -> (Channel<S, R>, Channel<R, S>)
-where
-    S: Send,
-    R: Send,
-{
-    let (tx1, rx1) = mpsc::channel(tx_buffer);
-    let (tx2, rx2) = mpsc::channel(rx_buffer);
-
-    let tx1 = PollSender::new(tx1);
-    let tx2 = PollSender::new(tx2);
-
-    (Channel { tx: tx1, rx: rx2 }, Channel { tx: tx2, rx: rx1 })
-}
-
-impl<S: Send + 'static, R> Channel<S, R> {
-    /// Sends a value, waiting until there is capacity.
-    ///
-    /// A successful send occurs when it is determined that the other end of the
-    /// channel has not hung up already. An unsuccessful send would be one where
-    /// the corresponding receiver has already been closed. Note that a return
-    /// value of `Err` means that the data will never be received, but a return
-    /// value of `Ok` does not mean that the data will be received. It is
-    /// possible for the corresponding receiver to hang up immediately after
-    /// this function returns `Ok`.
-    pub async fn send(&mut self, msg: S) -> Result<(), PollSendError<S>> {
-        self.tx.send(msg).await
-    }
-
-    /// Attempts to immediately send a message on this [`Sender`]
-    ///
-    /// This method differs from [`send`] by returning immediately if the channel's
-    /// buffer is full or no receiver is waiting to acquire some data. Compared
-    /// with [`send`], this function has two failure cases instead of one (one for
-    /// disconnection, one for a full buffer).
-    pub fn try_send(&mut self, msg: S) -> Result<(), TrySendError<S>> {
-        if let Some(tx) = self.tx.get_ref() {
-            tx.try_send(msg)
-        } else {
-            Err(TrySendError::Closed(msg))
-        }
-    }
-
-    /// Receives the next value for this receiver.
-    ///
-    /// This method returns `None` if the channel has been closed and there are
-    /// no remaining messages in the channel's buffer. This indicates that no
-    /// further values can ever be received from this `Receiver`. The channel is
-    /// closed when all senders have been dropped, or when [`close`] is called.
-    ///
-    /// If there are no messages in the channel's buffer, but the channel has
-    /// not yet been closed, this method will sleep until a message is sent or
-    /// the channel is closed.  Note that if [`close`] is called, but there are
-    /// still outstanding [`Permits`] from before it was closed, the channel is
-    /// not considered closed by `recv` until the permits are released.
-    pub async fn recv(&mut self) -> Option<R> {
-        self.rx.recv().await
-    }
-
-    /// Tries to receive the next value for this receiver.
-    ///
-    /// This method returns the [`Empty`](TryRecvError::Empty) error if the channel is currently
-    /// empty, but there are still outstanding [senders] or [permits].
-    ///
-    /// This method returns the [`Disconnected`](TryRecvError::Disconnected) error if the channel is
-    /// currently empty, and there are no outstanding [senders] or [permits].
-    ///
-    /// Unlike the [`poll_recv`](Self::poll_recv) method, this method will never return an
-    /// [`Empty`](TryRecvError::Empty) error spuriously.
-    pub fn try_recv(&mut self) -> Result<R, TryRecvError> {
-        self.rx.try_recv()
-    }
-
-    /// Polls to receive the next message on this channel.
-    ///
-    /// This method returns:
-    ///
-    ///  * `Poll::Pending` if no messages are available but the channel is not
-    ///    closed, or if a spurious failure happens.
-    ///  * `Poll::Ready(Some(message))` if a message is available.
-    ///  * `Poll::Ready(None)` if the channel has been closed and all messages
-    ///    sent before it was closed have been received.
-    ///
-    /// When the method returns `Poll::Pending`, the `Waker` in the provided
-    /// `Context` is scheduled to receive a wakeup when a message is sent on any
-    /// receiver, or when the channel is closed.  Note that on multiple calls to
-    /// `poll_recv`, only the `Waker` from the `Context` passed to the most
-    /// recent call is scheduled to receive a wakeup.
-    ///
-    /// If this method returns `Poll::Pending` due to a spurious failure, then
-    /// the `Waker` will be notified when the situation causing the spurious
-    /// failure has been resolved. Note that receiving such a wakeup does not
-    /// guarantee that the next call will succeed — it could fail with another
-    /// spurious failure.
-    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<R>> {
-        self.rx.poll_recv(cx)
-    }
-}
-
-impl<S, R> Stream for Channel<S, R> {
-    type Item = R;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.rx.poll_recv(cx)
-    }
-}
-
-impl<S: Send + 'static, R> Sink<S> for Channel<S, R> {
-    type Error = PollSendError<S>;
-
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.tx.poll_ready_unpin(cx)
-    }
-
-    fn start_send(mut self: Pin<&mut Self>, item: S) -> Result<(), Self::Error> {
-        self.tx.start_send_unpin(item)
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.tx.poll_flush_unpin(cx)
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.tx.poll_close_unpin(cx)
-    }
 }

--- a/msg-common/src/task.rs
+++ b/msg-common/src/task.rs
@@ -6,8 +6,8 @@ use std::{
 use tokio::task::{JoinError, JoinSet};
 
 /// A collection of keyed tasks spawned on a Tokio runtime.
-/// Hacky implementation of a join set that allows for a key to be associated with each task by having
-/// the task return a tuple of (key, value).
+/// Hacky implementation of a join set that allows for a key to be associated with each task by
+/// having the task return a tuple of (key, value).
 #[derive(Debug, Default)]
 pub struct JoinMap<K, V> {
     keys: HashSet<K>,
@@ -17,10 +17,7 @@ pub struct JoinMap<K, V> {
 impl<K, V> JoinMap<K, V> {
     /// Create a new `JoinSet`.
     pub fn new() -> Self {
-        Self {
-            keys: HashSet::new(),
-            joinset: JoinSet::new(),
-        }
+        Self { keys: HashSet::new(), joinset: JoinSet::new() }
     }
 
     /// Returns the number of tasks currently in the `JoinSet`.
@@ -71,7 +68,8 @@ where
 
     /// Polls for one of the tasks in the set to complete.
     ///
-    /// If this returns `Poll::Ready(Some(_))`, then the task that completed is removed from the set.
+    /// If this returns `Poll::Ready(Some(_))`, then the task that completed is removed from the
+    /// set.
     ///
     /// When the method returns `Poll::Pending`, the `Waker` in the provided `Context` is scheduled
     /// to receive a wakeup when a task in the `JoinSet` completes. Note that on multiple calls to
@@ -83,11 +81,11 @@ where
     /// This function returns:
     ///
     ///  * `Poll::Pending` if the `JoinSet` is not empty but there is no task whose output is
-    ///     available right now.
-    ///  * `Poll::Ready(Some(Ok(value)))` if one of the tasks in this `JoinSet` has completed.
-    ///     The `value` is the return value of one of the tasks that completed.
+    ///    available right now.
+    ///  * `Poll::Ready(Some(Ok(value)))` if one of the tasks in this `JoinSet` has completed. The
+    ///    `value` is the return value of one of the tasks that completed.
     ///  * `Poll::Ready(Some(Err(err)))` if one of the tasks in this `JoinSet` has panicked or been
-    ///     aborted. The `err` is the `JoinError` from the panicked/aborted task.
+    ///    aborted. The `err` is the `JoinError` from the panicked/aborted task.
     ///  * `Poll::Ready(None)` if the `JoinSet` is empty.
     ///
     /// Note that this method may return `Poll::Pending` even if one of the tasks has completed.

--- a/msg-sim/src/lib.rs
+++ b/msg-sim/src/lib.rs
@@ -34,10 +34,7 @@ pub struct Simulator {
 
 impl Simulator {
     pub fn new() -> Self {
-        Self {
-            active_sims: HashMap::new(),
-            sim_id: 1,
-        }
+        Self { active_sims: HashMap::new(), sim_id: 1 }
     }
 
     /// Starts a new simulation on the given endpoint according to the config.
@@ -108,9 +105,8 @@ impl Simulation {
             pipe = pipe.plr(plr);
         }
 
-        let mut pf = PacketFilter::new(pipe)
-            .anchor(format!("msg-sim-{}", self.id))
-            .endpoint(self.endpoint);
+        let mut pf =
+            PacketFilter::new(pipe).anchor(format!("msg-sim-{}", self.id)).endpoint(self.endpoint);
 
         if !self.config.protocols.is_empty() {
             pf = pf.protocols(self.config.protocols.clone());

--- a/msg-socket/src/connection/backoff.rs
+++ b/msg-socket/src/connection/backoff.rs
@@ -24,12 +24,7 @@ pub struct ExponentialBackoff {
 
 impl ExponentialBackoff {
     pub fn new(initial: Duration, max_retries: usize) -> Self {
-        Self {
-            retry_count: 0,
-            max_retries,
-            backoff: initial,
-            timeout: None,
-        }
+        Self { retry_count: 0, max_retries, backoff: initial, timeout: None }
     }
 
     /// (Re)-set the timeout to the current backoff duration.

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -91,8 +91,8 @@ impl PubOptions {
         self
     }
 
-    /// Sets the minimum payload size in bytes for compression to be used. If the payload is smaller than
-    /// this threshold, it will not be compressed.
+    /// Sets the minimum payload size in bytes for compression to be used. If the payload is smaller
+    /// than this threshold, it will not be compressed.
     pub fn min_compress_size(mut self, min_compress_size: usize) -> Self {
         self.min_compress_size = min_compress_size;
         self
@@ -200,10 +200,7 @@ mod tests {
         sub_socket.subscribe("HELLO".to_string()).await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        pub_socket
-            .publish("HELLO".to_string(), "WORLD".into())
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO".to_string(), "WORLD".into()).await.unwrap();
 
         let msg = sub_socket.next().await.unwrap();
         info!("Received message: {:?}", msg);
@@ -229,10 +226,7 @@ mod tests {
         sub_socket.subscribe("HELLO".to_string()).await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        pub_socket
-            .publish("HELLO".to_string(), "WORLD".into())
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO".to_string(), "WORLD".into()).await.unwrap();
 
         let msg = sub_socket.next().await.unwrap();
         info!("Received message: {:?}", msg);
@@ -258,10 +252,7 @@ mod tests {
         sub_socket.subscribe("HELLO".to_string()).await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        pub_socket
-            .publish("HELLO".to_string(), "WORLD".into())
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO".to_string(), "WORLD".into()).await.unwrap();
 
         let msg = sub_socket.next().await.unwrap();
         info!("Received message: {:?}", msg);
@@ -288,10 +279,7 @@ mod tests {
         sub2.subscribe("HELLO".to_string()).await.unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        pub_socket
-            .publish("HELLO".to_string(), Bytes::from("WORLD"))
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO".to_string(), Bytes::from("WORLD")).await.unwrap();
 
         let msg = sub1.next().await.unwrap();
         info!("Received message: {:?}", msg);
@@ -325,10 +313,7 @@ mod tests {
 
         let original_msg = Bytes::from("WOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOORLD");
 
-        pub_socket
-            .publish("HELLO".to_string(), original_msg.clone())
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO".to_string(), original_msg.clone()).await.unwrap();
 
         let msg = sub1.next().await.unwrap();
         info!("Received message: {:?}", msg);
@@ -357,10 +342,7 @@ mod tests {
         pub_socket.bind("0.0.0.0:6662").await.unwrap();
         tokio::time::sleep(Duration::from_millis(2000)).await;
 
-        pub_socket
-            .publish("HELLO".to_string(), Bytes::from("WORLD"))
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO".to_string(), Bytes::from("WORLD")).await.unwrap();
 
         let msg = sub_socket.next().await.unwrap();
         info!("Received message: {:?}", msg);
@@ -384,10 +366,7 @@ mod tests {
         pub_socket.bind("0.0.0.0:6662").await.unwrap();
         tokio::time::sleep(Duration::from_millis(2000)).await;
 
-        pub_socket
-            .publish("HELLO".to_string(), Bytes::from("WORLD"))
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO".to_string(), Bytes::from("WORLD")).await.unwrap();
 
         let msg = sub_socket.next().await.unwrap();
         info!("Received message: {:?}", msg);

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -170,6 +170,7 @@ mod tests {
     use futures::StreamExt;
     use msg_transport::{quic::Quic, tcp::Tcp};
     use msg_wire::compression::GzipCompressor;
+    use tracing::info;
 
     use crate::{Authenticator, SubOptions, SubSocket};
 
@@ -179,7 +180,7 @@ mod tests {
 
     impl Authenticator for Auth {
         fn authenticate(&self, id: &Bytes) -> bool {
-            tracing::info!("Auth request from: {:?}", id);
+            info!("Auth request from: {:?}", id);
             true
         }
     }
@@ -205,7 +206,7 @@ mod tests {
             .unwrap();
 
         let msg = sub_socket.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!("WORLD", msg.payload());
     }
@@ -234,7 +235,7 @@ mod tests {
             .unwrap();
 
         let msg = sub_socket.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!("WORLD", msg.payload());
     }
@@ -263,7 +264,7 @@ mod tests {
             .unwrap();
 
         let msg = sub_socket.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!("WORLD", msg.payload());
     }
@@ -293,12 +294,12 @@ mod tests {
             .unwrap();
 
         let msg = sub1.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!("WORLD", msg.payload());
 
         let msg = sub2.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!("WORLD", msg.payload());
     }
@@ -330,12 +331,12 @@ mod tests {
             .unwrap();
 
         let msg = sub1.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!(original_msg, msg.payload());
 
         let msg = sub2.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!(original_msg, msg.payload());
     }
@@ -362,7 +363,7 @@ mod tests {
             .unwrap();
 
         let msg = sub_socket.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!("WORLD", msg.payload());
     }
@@ -389,7 +390,7 @@ mod tests {
             .unwrap();
 
         let msg = sub_socket.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!("HELLO", msg.topic());
         assert_eq!("WORLD", msg.payload());
     }

--- a/msg-socket/src/pub/trie.rs
+++ b/msg-socket/src/pub/trie.rs
@@ -10,11 +10,7 @@ struct Node {
 
 impl Node {
     fn new() -> Self {
-        Self {
-            children: FxHashMap::default(),
-            catch_all: false,
-            topic_end: false,
-        }
+        Self { children: FxHashMap::default(), catch_all: false, topic_end: false }
     }
 }
 
@@ -36,10 +32,7 @@ impl PrefixTrie {
     pub fn insert(&mut self, topic: &str) {
         let mut node = &mut self.root;
         for token in topic.split('.') {
-            node = node
-                .children
-                .entry(token.to_string())
-                .or_insert(Node::new());
+            node = node.children.entry(token.to_string()).or_insert(Node::new());
             // Check if this is a catch-all wildcard. If so, we mark it as such and break.
             if token == ">" {
                 node.catch_all = true;

--- a/msg-socket/src/rep/driver.rs
+++ b/msg-socket/src/rep/driver.rs
@@ -122,7 +122,7 @@ where
                         );
                     }
                     Err(e) => {
-                        tracing::error!("Error authenticating client: {:?}", e);
+                        error!("Error authenticating client: {:?}", e);
                         this.state.stats.decrement_active_clients();
                     }
                 }
@@ -279,7 +279,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, A: Address + Unpin> Stream for PeerState
                         }
                         Err(e) => {
                             this.state.stats.increment_failed_requests();
-                            tracing::error!("Failed to send message to socket: {:?}", e);
+                            error!("Failed to send message to socket: {:?}", e);
                             // End this stream as we can't send any more messages
                             return Poll::Ready(None);
                         }
@@ -300,12 +300,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin, A: Address + Unpin> Stream for PeerState
                             compression_type = compressor.compression_type() as u8;
                         }
                         Err(e) => {
-                            tracing::error!("Failed to compress message: {:?}", e);
+                            error!("Failed to compress message: {:?}", e);
                             continue;
                         }
                     }
 
-                    tracing::debug!(
+                    debug!(
                         "Compressed message {} from {} to {} bytes",
                         id,
                         len_before,

--- a/msg-socket/src/rep/driver.rs
+++ b/msg-socket/src/rep/driver.rs
@@ -82,7 +82,7 @@ where
                         match try_decompress_payload(request.compression_type, request.msg) {
                             Ok(decompressed) => request.msg = decompressed,
                             Err(e) => {
-                                error!("Failed to decompress message: {:?}", e);
+                                error!(err = ?e, "Failed to decompress message");
                                 continue;
                             }
                         }
@@ -91,7 +91,7 @@ where
                         let _ = this.to_socket.try_send(request);
                     }
                     Some(Err(e)) => {
-                        error!("Error receiving message from peer {:?}: {:?}", peer, e);
+                        error!(err = ?e, "Error receiving message from peer {:?}", peer);
                     }
                     None => {
                         warn!("Peer {:?} disconnected", peer);
@@ -122,7 +122,7 @@ where
                         );
                     }
                     Err(e) => {
-                        error!("Error authenticating client: {:?}", e);
+                        error!(err = ?e, "Error authenticating client");
                         this.state.stats.decrement_active_clients();
                     }
                 }
@@ -134,15 +134,15 @@ where
                 match incoming {
                     Ok(io) => {
                         if let Err(e) = this.on_incoming(io) {
-                            error!("Error accepting incoming connection: {:?}", e);
+                            error!(err = ?e, "Error accepting incoming connection");
                             this.state.stats.decrement_active_clients();
                         }
                     }
                     Err(e) => {
-                        error!("Error accepting incoming connection: {:?}", e);
+                        error!(err = ?e, "Error accepting incoming connection");
 
-                        // Active clients have already been incremented in the initial call to `poll_accept`,
-                        // so we need to decrement them here.
+                        // Active clients have already been incremented in the initial call to
+                        // `poll_accept`, so we need to decrement them here.
                         this.state.stats.decrement_active_clients();
                     }
                 }
@@ -150,7 +150,8 @@ where
                 continue;
             }
 
-            // Finally, poll the transport for new incoming connection futures and push them to the incoming connection tasks.
+            // Finally, poll the transport for new incoming connection futures and push them to the
+            // incoming connection tasks.
             if let Poll::Ready(accept) = Pin::new(&mut this.transport).poll_accept(cx) {
                 if let Some(max) = this.options.max_clients {
                     if this.state.stats.active_clients() >= max {
@@ -225,11 +226,7 @@ where
                 conn.send(auth::Message::Ack).await?;
                 conn.flush().await?;
 
-                Ok(AuthResult {
-                    id,
-                    addr,
-                    stream: conn.into_inner(),
-                })
+                Ok(AuthResult { id, addr, stream: conn.into_inner() })
             });
         } else {
             self.peer_states.insert(
@@ -279,7 +276,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, A: Address + Unpin> Stream for PeerState
                         }
                         Err(e) => {
                             this.state.stats.increment_failed_requests();
-                            error!("Failed to send message to socket: {:?}", e);
+                            error!(err = ?e, "Failed to send message to socket");
                             // End this stream as we can't send any more messages
                             return Poll::Ready(None);
                         }
@@ -300,7 +297,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, A: Address + Unpin> Stream for PeerState
                             compression_type = compressor.compression_type() as u8;
                         }
                         Err(e) => {
-                            error!("Failed to compress message: {:?}", e);
+                            error!(err = ?e, "Failed to compress message");
                             continue;
                         }
                     }
@@ -328,10 +325,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, A: Address + Unpin> Stream for PeerState
                     let (tx, rx) = oneshot::channel();
 
                     // Add the pending request to the list
-                    this.pending_requests.push(PendingRequest {
-                        msg_id: msg.id(),
-                        response: rx,
-                    });
+                    this.pending_requests.push(PendingRequest { msg_id: msg.id(), response: rx });
 
                     let request = Request {
                         source: this.addr.clone(),

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -33,10 +33,7 @@ pub struct RepOptions {
 
 impl Default for RepOptions {
     fn default() -> Self {
-        Self {
-            max_clients: None,
-            min_compress_size: 8192,
-        }
+        Self { max_clients: None, min_compress_size: 8192 }
     }
 }
 
@@ -86,9 +83,7 @@ impl<A: Address> Request<A> {
 
     /// Responds to the request.
     pub fn respond(self, response: Bytes) -> Result<(), PubError> {
-        self.response
-            .send(response)
-            .map_err(|_| PubError::SocketClosed)
+        self.response.send(response).map_err(|_| PubError::SocketClosed)
     }
 }
 

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -100,6 +100,7 @@ mod tests {
     use msg_transport::tcp::Tcp;
     use msg_wire::compression::{GzipCompressor, SnappyCompressor};
     use rand::Rng;
+    use tracing::{debug, info};
 
     use crate::{req::ReqSocket, Authenticator, ReqOptions};
 
@@ -142,7 +143,7 @@ mod tests {
             // println!("Response: {:?} {:?}", _res, req_start.elapsed());
         }
         let elapsed = start.elapsed();
-        tracing::info!("{} reqs in {:?}", n_reqs, elapsed);
+        info!("{} reqs in {:?}", n_reqs, elapsed);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -186,7 +187,7 @@ mod tests {
 
         impl Authenticator for Auth {
             fn authenticate(&self, _id: &Bytes) -> bool {
-                tracing::info!("{:?}", _id);
+                info!("{:?}", _id);
                 true
             }
         }
@@ -203,12 +204,12 @@ mod tests {
 
         req.connect(rep.local_addr().unwrap()).await.unwrap();
 
-        tracing::info!("Connected to rep");
+        info!("Connected to rep");
 
         tokio::spawn(async move {
             loop {
                 let req = rep.next().await.unwrap();
-                tracing::debug!("Received request");
+                debug!("Received request");
 
                 req.respond(Bytes::from("hello")).unwrap();
             }
@@ -229,7 +230,7 @@ mod tests {
             let _res = req.request(msg).await.unwrap();
         }
         let elapsed = start.elapsed();
-        tracing::info!("{} reqs in {:?}", n_reqs, elapsed);
+        info!("{} reqs in {:?}", n_reqs, elapsed);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -35,10 +35,7 @@ pub enum ReqError {
 }
 
 pub enum Command {
-    Send {
-        message: ReqMessage,
-        response: oneshot::Sender<Result<Bytes, ReqError>>,
-    },
+    Send { message: ReqMessage, response: oneshot::Sender<Result<Bytes, ReqError>> },
 }
 
 #[derive(Debug, Clone)]
@@ -88,29 +85,32 @@ impl ReqOptions {
         self
     }
 
-    /// Sets the flush interval for the socket. A higher flush interval will result in higher throughput,
-    /// but at the cost of higher latency. Note that this behaviour can be completely useless if the
-    /// `backpressure_boundary` is set too low (which will trigger a flush before the interval is reached).
+    /// Sets the flush interval for the socket. A higher flush interval will result in higher
+    /// throughput, but at the cost of higher latency. Note that this behaviour can be
+    /// completely useless if the `backpressure_boundary` is set too low (which will trigger a
+    /// flush before the interval is reached).
     pub fn flush_interval(mut self, flush_interval: Duration) -> Self {
         self.flush_interval = Some(flush_interval);
         self
     }
 
-    /// Sets the backpressure boundary for the socket. This is the maximum number of bytes that can be buffered
-    /// in the session before being flushed. This internally sets [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
+    /// Sets the backpressure boundary for the socket. This is the maximum number of bytes that can
+    /// be buffered in the session before being flushed. This internally sets
+    /// [`Framed::set_backpressure_boundary`](tokio_util::codec::Framed).
     pub fn backpressure_boundary(mut self, backpressure_boundary: usize) -> Self {
         self.backpressure_boundary = backpressure_boundary;
         self
     }
 
-    /// Sets the maximum number of retry attempts. If `None`, all connections will be retried indefinitely.
+    /// Sets the maximum number of retry attempts. If `None`, all connections will be retried
+    /// indefinitely.
     pub fn retry_attempts(mut self, retry_attempts: usize) -> Self {
         self.retry_attempts = Some(retry_attempts);
         self
     }
 
-    /// Sets the minimum payload size in bytes for compression to be used. If the payload is smaller than
-    /// this threshold, it will not be compressed.
+    /// Sets the minimum payload size in bytes for compression to be used. If the payload is smaller
+    /// than this threshold, it will not be compressed.
     pub fn min_compress_size(mut self, min_compress_size: usize) -> Self {
         self.min_compress_size = min_compress_size;
         self

--- a/msg-socket/src/sub/driver.rs
+++ b/msg-socket/src/sub/driver.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::{ConnectionState, ExponentialBackoff};
 
-use msg_common::{channel, task::JoinMap, Channel};
+use msg_common::{channel, Channel, JoinMap};
 use msg_transport::{Address, Transport};
 use msg_wire::{auth, compression::try_decompress_payload, pubsub};
 

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -72,8 +72,9 @@ impl SubOptions {
         self
     }
 
-    /// Sets the ingress buffer size. This is the maximum amount of incoming messages that will be buffered.
-    /// If the consumer cannot keep up with the incoming messages, messages will start being dropped.
+    /// Sets the ingress buffer size. This is the maximum amount of incoming messages that will be
+    /// buffered. If the consumer cannot keep up with the incoming messages, messages will start
+    /// being dropped.
     pub fn ingress_buffer_size(mut self, ingress_buffer_size: usize) -> Self {
         self.ingress_buffer_size = ingress_buffer_size;
         self
@@ -128,11 +129,7 @@ impl<A: Address> fmt::Debug for PubMessage<A> {
 
 impl<A: Address> PubMessage<A> {
     pub fn new(source: A, topic: String, payload: Bytes) -> Self {
-        Self {
-            source,
-            topic,
-            payload,
-        }
+        Self { source, topic, payload }
     }
 
     #[inline]
@@ -164,9 +161,7 @@ pub(crate) struct SocketState<A: Address> {
 
 impl<A: Address> SocketState<A> {
     pub fn new() -> Self {
-        Self {
-            stats: SocketStats::new(),
-        }
+        Self { stats: SocketStats::new() }
     }
 }
 

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -1,19 +1,23 @@
+use std::{fmt, time::Duration};
+
 use bytes::Bytes;
-use core::fmt;
-use msg_transport::Address;
-use msg_wire::pubsub;
-use std::time::Duration;
 use thiserror::Error;
 
 mod driver;
+use driver::SubDriver;
+
 mod session;
+
 mod socket;
+pub use socket::*;
+
 mod stats;
+use stats::SocketStats;
+
 mod stream;
 
-use driver::SubDriver;
-pub use socket::*;
-use stats::SocketStats;
+use msg_transport::Address;
+use msg_wire::pubsub;
 
 const DEFAULT_BUFFER_SIZE: usize = 1024;
 
@@ -176,7 +180,7 @@ mod tests {
         net::TcpListener,
     };
     use tokio_stream::StreamExt;
-    use tracing::Instrument;
+    use tracing::{info, info_span, Instrument};
 
     use super::*;
 
@@ -193,11 +197,11 @@ mod tests {
                 let b = socket.read(&mut buf).await.unwrap();
                 let read = &buf[..b];
 
-                tracing::info!("Received bytes: {:?}", read);
+                info!("Received bytes: {:?}", read);
                 socket.write_all(read).await.unwrap();
                 socket.flush().await.unwrap();
             }
-            .instrument(tracing::info_span!("listener")),
+            .instrument(info_span!("listener")),
         );
 
         addr

--- a/msg-socket/src/sub/socket.rs
+++ b/msg-socket/src/sub/socket.rs
@@ -1,5 +1,3 @@
-use futures::Stream;
-use rustc_hash::FxHashMap;
 use std::{
     collections::HashSet,
     io,
@@ -9,12 +7,15 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+use futures::Stream;
+use rustc_hash::FxHashMap;
 use tokio::{
     net::{lookup_host, ToSocketAddrs},
     sync::mpsc,
 };
 
-use msg_common::task::JoinMap;
+use msg_common::JoinMap;
 use msg_transport::{Address, Transport};
 
 use super::{

--- a/msg-socket/src/sub/socket.rs
+++ b/msg-socket/src/sub/socket.rs
@@ -254,10 +254,7 @@ where
     /// Sends a command to the driver, returning [`SubError::SocketClosed`] if the
     /// driver has been dropped.
     async fn send_command(&self, command: Command<A>) -> Result<(), SubError> {
-        self.to_driver
-            .send(command)
-            .await
-            .map_err(|_| SubError::SocketClosed)?;
+        self.to_driver.send(command).await.map_err(|_| SubError::SocketClosed)?;
 
         Ok(())
     }

--- a/msg-socket/src/sub/stats.rs
+++ b/msg-socket/src/sub/stats.rs
@@ -19,9 +19,7 @@ pub struct SocketStats<A: Address> {
 
 impl<A: Address> SocketStats<A> {
     pub fn new() -> Self {
-        Self {
-            session_stats: RwLock::new(HashMap::new()),
-        }
+        Self { session_stats: RwLock::new(HashMap::new()) }
     }
 }
 
@@ -38,19 +36,13 @@ impl<A: Address> SocketStats<A> {
 
     #[inline]
     pub fn bytes_rx(&self, session_addr: &A) -> Option<usize> {
-        self.session_stats
-            .read()
-            .get(session_addr)
-            .map(|stats| stats.bytes_rx())
+        self.session_stats.read().get(session_addr).map(|stats| stats.bytes_rx())
     }
 
     /// Returns the average latency in microseconds for the given session.
     #[inline]
     pub fn avg_latency(&self, session_addr: &A) -> Option<u64> {
-        self.session_stats
-            .read()
-            .get(session_addr)
-            .map(|stats| stats.avg_latency())
+        self.session_stats.read().get(session_addr).map(|stats| stats.avg_latency())
     }
 }
 

--- a/msg-socket/src/sub/stream.rs
+++ b/msg-socket/src/sub/stream.rs
@@ -76,12 +76,7 @@ impl<Io: AsyncRead + AsyncWrite + Unpin> Stream for PublisherStream<Io> {
 
                 // TODO: this will allocate. Can we just return the `Cow`?
                 let topic = String::from_utf8_lossy(&topic).to_string();
-                TopicMessage {
-                    compression_type,
-                    timestamp,
-                    topic,
-                    payload,
-                }
+                TopicMessage { compression_type, timestamp, topic, payload }
             })));
         }
 

--- a/msg-socket/tests/README.md
+++ b/msg-socket/tests/README.md
@@ -1,6 +1,7 @@
 # `msg-socket` tests
 
 ## Integration tests
-| Test        | Description                  | Status |
-| ----------- | ---------------------------- | ------ |
-| [`pubsub`](./it/pubsub.rs) | Different messaging patterns with different transports, chaos through simulated network links & random delay injection. | ✅ |
+
+| Test                       | Description                                                                                                             | Status |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------ |
+| [`pubsub`](./it/pubsub.rs) | Different messaging patterns with different transports, chaos through simulated network links & random delay injection. | ✅     |

--- a/msg-socket/tests/it/pubsub.rs
+++ b/msg-socket/tests/it/pubsub.rs
@@ -1,9 +1,11 @@
+use std::{collections::HashSet, net::IpAddr, time::Duration};
+
 use bytes::Bytes;
 use msg_sim::{Protocol, SimulationConfig, Simulator};
 use rand::Rng;
-use std::{collections::HashSet, net::IpAddr, time::Duration};
 use tokio::{sync::mpsc, task::JoinSet};
 use tokio_stream::StreamExt;
+use tracing::info;
 
 use msg_socket::{PubSocket, SubSocket};
 use msg_transport::{quic::Quic, tcp::Tcp, Address, Transport};
@@ -77,7 +79,7 @@ where
     });
 
     let msg = subscriber.next().await.unwrap();
-    tracing::info!("Received message: {:?}", msg);
+    info!("Received message: {:?}", msg);
     assert_eq!(TOPIC, msg.topic());
     assert_eq!("WORLD", msg.payload());
 
@@ -137,7 +139,7 @@ async fn pubsub_fan_out_transport<
             subscriber.subscribe(TOPIC).await.unwrap();
 
             let msg = subscriber.next().await.unwrap();
-            tracing::info!("Received message: {:?}", msg);
+            info!("Received message: {:?}", msg);
             assert_eq!(TOPIC, msg.topic());
             assert_eq!("WORLD", msg.payload());
         });
@@ -254,7 +256,7 @@ async fn pubsub_fan_in_transport<
         }
 
         let msg = subscriber.next().await.unwrap();
-        tracing::info!("Received message: {:?}", msg);
+        info!("Received message: {:?}", msg);
         assert_eq!(TOPIC, msg.topic());
         assert_eq!("WORLD", msg.payload());
 

--- a/msg-socket/tests/it/pubsub.rs
+++ b/msg-socket/tests/it/pubsub.rs
@@ -67,14 +67,12 @@ where
 
     publisher.try_bind(vec![addr]).await?;
 
-    // Spawn a task to keep sending messages until the subscriber receives one (after connection process)
+    // Spawn a task to keep sending messages until the subscriber receives one (after connection
+    // process)
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            publisher
-                .publish(TOPIC, Bytes::from("WORLD"))
-                .await
-                .unwrap();
+            publisher.publish(TOPIC, Bytes::from("WORLD")).await.unwrap();
         }
     });
 
@@ -149,14 +147,12 @@ async fn pubsub_fan_out_transport<
 
     publisher.try_bind(vec![addr]).await?;
 
-    // Spawn a task to keep sending messages until the subscriber receives one (after connection process)
+    // Spawn a task to keep sending messages until the subscriber receives one (after connection
+    // process)
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            publisher
-                .publish(TOPIC, Bytes::from("WORLD"))
-                .await
-                .unwrap();
+            publisher.publish(TOPIC, Bytes::from("WORLD")).await.unwrap();
         }
     });
 
@@ -221,14 +217,12 @@ async fn pubsub_fan_in_transport<
             let local_addr = publisher.local_addr().unwrap().clone();
             tx.send(local_addr).await.unwrap();
 
-            // Spawn a task to keep sending messages until the subscriber receives one (after connection process)
+            // Spawn a task to keep sending messages until the subscriber receives one (after
+            // connection process)
             tokio::spawn(async move {
                 loop {
                     tokio::time::sleep(Duration::from_millis(500)).await;
-                    publisher
-                        .publish(TOPIC, Bytes::from("WORLD"))
-                        .await
-                        .unwrap();
+                    publisher.publish(TOPIC, Bytes::from("WORLD")).await.unwrap();
                 }
             });
         });

--- a/msg-transport/src/ipc/mod.rs
+++ b/msg-transport/src/ipc/mod.rs
@@ -42,11 +42,7 @@ pub struct Ipc {
 
 impl Ipc {
     pub fn new(config: Config) -> Self {
-        Self {
-            config,
-            listener: None,
-            path: None,
-        }
+        Self { config, listener: None, path: None }
     }
 }
 
@@ -115,7 +111,7 @@ impl Transport<PathBuf> for Ipc {
             if let Err(e) = std::fs::remove_file(&addr) {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
-                    format!("Failed to remove existing socket file: {}", e),
+                    format!("Failed to remove existing socket file, {:?}", e),
                 ));
             }
         }

--- a/msg-transport/src/lib.rs
+++ b/msg-transport/src/lib.rs
@@ -59,7 +59,8 @@ pub trait Transport<A: Address> {
     /// Binds to the given address.
     async fn bind(&mut self, addr: A) -> Result<(), Self::Error>;
 
-    /// Connects to the given address, returning a future representing a pending outbound connection.
+    /// Connects to the given address, returning a future representing a
+    /// pending outbound connection.
     fn connect(&mut self, addr: A) -> Self::Connect;
 
     /// Poll for incoming connections. If an inbound connection is received, a future representing
@@ -84,10 +85,7 @@ pub struct Acceptor<'a, T, A> {
 
 impl<'a, T, A> Acceptor<'a, T, A> {
     fn new(inner: &'a mut T) -> Self {
-        Self {
-            inner,
-            _marker: PhantomData,
-        }
+        Self { inner, _marker: PhantomData }
     }
 }
 

--- a/msg-transport/src/quic/config.rs
+++ b/msg-transport/src/quic/config.rs
@@ -113,11 +113,7 @@ where
 
         client_config.transport_config(transport);
 
-        Config {
-            endpoint_config: quinn::EndpointConfig::default(),
-            client_config,
-            server_config,
-        }
+        Config { endpoint_config: quinn::EndpointConfig::default(), client_config, server_config }
     }
 }
 
@@ -170,10 +166,6 @@ impl Default for Config {
 
         client_config.transport_config(transport);
 
-        Self {
-            endpoint_config: quinn::EndpointConfig::default(),
-            client_config,
-            server_config,
-        }
+        Self { endpoint_config: quinn::EndpointConfig::default(), client_config, server_config }
     }
 }

--- a/msg-transport/src/quic/mod.rs
+++ b/msg-transport/src/quic/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use futures::future::BoxFuture;
 use thiserror::Error;
 use tokio::sync::mpsc::{self, Receiver};
-use tracing::error;
+use tracing::{debug, error};
 
 use crate::{Acceptor, Transport, TransportExt};
 
@@ -133,7 +133,7 @@ impl Transport<SocketAddr> for Quic {
                 .await
                 .map_err(Error::from)?;
 
-            tracing::debug!("Connected to {}, opening stream", addr);
+            debug!("Connected to {}, opening stream", addr);
 
             // Open a bi-directional stream and return it. We'll think about multiplexing per topic later.
             connection
@@ -159,12 +159,12 @@ impl Transport<SocketAddr> for Quic {
                     Some(Ok(connecting)) => {
                         let peer = connecting.remote_address();
 
-                        tracing::debug!("New incoming connection from {}", peer);
+                        debug!("New incoming connection from {}", peer);
 
                         // Return a future that resolves to the output.
                         return Poll::Ready(Box::pin(async move {
                             let connection = connecting.await.map_err(Error::from)?;
-                            tracing::debug!(
+                            debug!(
                                 "Accepted connection from {}, opening stream",
                                 connection.remote_address()
                             );
@@ -235,6 +235,7 @@ mod tests {
         io::{AsyncReadExt, AsyncWriteExt},
         sync::oneshot,
     };
+    use tracing::info;
 
     use super::*;
 
@@ -251,7 +252,7 @@ mod tests {
             .unwrap();
 
         let server_addr = server.local_addr().unwrap();
-        tracing::info!("Server bound on {:?}", server_addr);
+        info!("Server bound on {:?}", server_addr);
 
         let (tx, rx) = oneshot::channel();
 
@@ -260,7 +261,7 @@ mod tests {
 
             let mut stream = server.accept().await.unwrap();
 
-            tracing::info!("Accepted connection");
+            info!("Accepted connection");
 
             let mut dst = [0u8; 5];
 
@@ -273,13 +274,13 @@ mod tests {
         let mut client = Quic::new(config);
 
         let mut stream = client.connect(server_addr).await.unwrap();
-        tracing::info!("Connected to remote");
+        info!("Connected to remote");
 
         let item = b"Hello";
         stream.write_all(item).await.unwrap();
         stream.flush().await.unwrap();
 
-        tracing::info!("Wrote to remote");
+        info!("Wrote to remote");
         let rcv = rx.await.unwrap();
 
         assert_eq!(rcv, *item);
@@ -299,7 +300,7 @@ mod tests {
 
         tokio::spawn(async move {
             let _stream = client.connect(addr).await.unwrap();
-            tracing::info!("Connected to remote");
+            info!("Connected to remote");
         });
 
         tokio::time::sleep(Duration::from_secs(17)).await;

--- a/msg-transport/src/tcp/mod.rs
+++ b/msg-transport/src/tcp/mod.rs
@@ -23,10 +23,7 @@ pub struct Tcp {
 
 impl Tcp {
     pub fn new(config: Config) -> Self {
-        Self {
-            config,
-            listener: None,
-        }
+        Self { config, listener: None }
     }
 }
 

--- a/msg-transport/src/tcp/mod.rs
+++ b/msg-transport/src/tcp/mod.rs
@@ -5,6 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::net::{TcpListener, TcpStream};
+use tracing::debug;
 
 use msg_common::async_error;
 
@@ -74,7 +75,7 @@ impl Transport<SocketAddr> for Tcp {
 
         match listener.poll_accept(cx) {
             Poll::Ready(Ok((io, addr))) => {
-                tracing::debug!("Accepted connection from {}", addr);
+                debug!("Accepted connection from {}", addr);
 
                 Poll::Ready(Box::pin(async move {
                     io.set_nodelay(true)?;

--- a/msg-wire/src/auth.rs
+++ b/msg-wire/src/auth.rs
@@ -31,9 +31,7 @@ impl Codec {
     /// codec in the `AuthReceive` state since it will be waiting for the
     /// client to send its ID.
     pub fn new_server() -> Self {
-        Self {
-            state: State::AuthReceive,
-        }
+        Self { state: State::AuthReceive }
     }
 }
 

--- a/msg-wire/src/compression/gzip.rs
+++ b/msg-wire/src/compression/gzip.rs
@@ -23,10 +23,8 @@ impl Compressor for GzipCompressor {
 
     fn compress(&self, data: &[u8]) -> Result<Bytes, io::Error> {
         // Optimistically allocate the compressed buffer to 1/4 of the original size.
-        let mut encoder = GzEncoder::new(
-            Vec::with_capacity(data.len() / 4),
-            Compression::new(self.level),
-        );
+        let mut encoder =
+            GzEncoder::new(Vec::with_capacity(data.len() / 4), Compression::new(self.level));
 
         encoder.write_all(data)?;
 

--- a/msg-wire/src/compression/lz4.rs
+++ b/msg-wire/src/compression/lz4.rs
@@ -26,10 +26,7 @@ pub struct Lz4Decompressor;
 impl Decompressor for Lz4Decompressor {
     fn decompress(&self, data: &[u8]) -> Result<Bytes, io::Error> {
         let bytes = decompress_size_prepended(data).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Lz4 decompression failed: {}", e),
-            )
+            io::Error::new(io::ErrorKind::InvalidData, format!("Lz4 decompression failed: {}", e))
         })?;
 
         Ok(Bytes::from(bytes))

--- a/msg-wire/src/compression/mod.rs
+++ b/msg-wire/src/compression/mod.rs
@@ -170,31 +170,19 @@ mod tests {
 
         let gzip = GzipCompressor::new(6);
         let (gzip_time, gzip_perf, gzip_comp) = compression_test(&data, gzip);
-        println!(
-            "gzip compression shrank the data by {:.2}% in {:?}",
-            gzip_perf, gzip_time
-        );
+        println!("gzip compression shrank the data by {:.2}% in {:?}", gzip_perf, gzip_time);
 
         let zstd = ZstdCompressor::new(6);
         let (zstd_time, zstd_perf, zstd_comp) = compression_test(&data, zstd);
-        println!(
-            "zstd compression shrank the data by {:.2}% in {:?}",
-            zstd_perf, zstd_time
-        );
+        println!("zstd compression shrank the data by {:.2}% in {:?}", zstd_perf, zstd_time);
 
         let snappy = SnappyCompressor;
         let (snappy_time, snappy_perf, snappy_comp) = compression_test(&data, snappy);
-        println!(
-            "snappy compression shrank the data by {:.2}% in {:?}",
-            snappy_perf, snappy_time
-        );
+        println!("snappy compression shrank the data by {:.2}% in {:?}", snappy_perf, snappy_time);
 
         let lz4 = Lz4Compressor;
         let (lz4_time, lz4_perf, lz4_comp) = compression_test(&data, lz4);
-        println!(
-            "lz4 compression shrank the data by {:.2}% in {:?}",
-            lz4_perf, lz4_time
-        );
+        println!("lz4 compression shrank the data by {:.2}% in {:?}", lz4_perf, lz4_time);
 
         println!("------ SSZ BLOCK -------");
 
@@ -225,31 +213,19 @@ mod tests {
 
         let gzip = GzipCompressor::new(6);
         let (gzip_time, gzip_perf, gzip_comp) = compression_test(&data, gzip);
-        println!(
-            "gzip compression shrank the data by {:.2}% in {:?}",
-            gzip_perf, gzip_time
-        );
+        println!("gzip compression shrank the data by {:.2}% in {:?}", gzip_perf, gzip_time);
 
         let zstd = ZstdCompressor::new(6);
         let (zstd_time, zstd_perf, zstd_comp) = compression_test(&data, zstd);
-        println!(
-            "zstd compression shrank the data by {:.2}% in {:?}",
-            zstd_perf, zstd_time
-        );
+        println!("zstd compression shrank the data by {:.2}% in {:?}", zstd_perf, zstd_time);
 
         let snappy = SnappyCompressor;
         let (snappy_time, snappy_perf, snappy_comp) = compression_test(&data, snappy);
-        println!(
-            "snappy compression shrank the data by {:.2}% in {:?}",
-            snappy_perf, snappy_time
-        );
+        println!("snappy compression shrank the data by {:.2}% in {:?}", snappy_perf, snappy_time);
 
         let lz4 = Lz4Compressor;
         let (lz4_time, lz4_perf, lz4_comp) = compression_test(&data, lz4);
-        println!(
-            "lz4 compression shrank the data by {:.2}% in {:?}",
-            lz4_perf, lz4_time
-        );
+        println!("lz4 compression shrank the data by {:.2}% in {:?}", lz4_perf, lz4_time);
 
         println!("------ BLOB TX ------");
 

--- a/msg-wire/src/pubsub.rs
+++ b/msg-wire/src/pubsub.rs
@@ -214,7 +214,8 @@ impl Decoder for Codec {
 
                     cursor += 2;
 
-                    // We don't have enough bytes to read the topic and the rest of the data (timestamp u64, seq u32, size u32)
+                    // We don't have enough bytes to read the topic and the rest of the data
+                    // (timestamp u64, seq u32, size u32)
                     if src.len() < cursor + topic_size as usize + 8 + 8 {
                         return Ok(None);
                     }
@@ -244,10 +245,7 @@ impl Decoder for Codec {
                     let header = header.take().unwrap();
 
                     let payload = src.split_to(header.size as usize);
-                    let message = Message {
-                        header,
-                        payload: payload.freeze(),
-                    };
+                    let message = Message { header, payload: payload.freeze() };
 
                     self.state = State::Header;
                     return Ok(Some(message));

--- a/msg-wire/src/reqrep.rs
+++ b/msg-wire/src/reqrep.rs
@@ -23,14 +23,7 @@ pub struct Message {
 impl Message {
     #[inline]
     pub fn new(id: u32, compression_type: u8, payload: Bytes) -> Self {
-        Self {
-            header: Header {
-                id,
-                compression_type,
-                size: payload.len() as u32,
-            },
-            payload,
-        }
+        Self { header: Header { id, compression_type, size: payload.len() as u32 }, payload }
     }
 
     #[inline]
@@ -151,11 +144,8 @@ impl Decoder for Codec {
                     src.advance(cursor);
 
                     // Construct the header
-                    let header = Header {
-                        compression_type,
-                        id: src.get_u32(),
-                        size: src.get_u32(),
-                    };
+                    let header =
+                        Header { compression_type, id: src.get_u32(), size: src.get_u32() };
 
                     self.state = State::Payload(header);
                 }
@@ -165,10 +155,7 @@ impl Decoder for Codec {
                     }
 
                     let payload = src.split_to(header.size as usize);
-                    let message = Message {
-                        header,
-                        payload: payload.freeze(),
-                    };
+                    let message = Message { header, payload: payload.freeze() };
 
                     self.state = State::Header;
                     return Ok(Some(message));

--- a/msg/benches/pubsub.rs
+++ b/msg/benches/pubsub.rs
@@ -43,10 +43,7 @@ impl<T: Transport<A> + Send + Sync + Unpin + 'static, A: Address> PairBenchmark<
             let addr = self.publisher.local_addr().unwrap();
             self.subscriber.connect_inner(addr.clone()).await.unwrap();
 
-            self.subscriber
-                .subscribe("HELLO".to_string())
-                .await
-                .unwrap();
+            self.subscriber.subscribe("HELLO".to_string()).await.unwrap();
 
             // Give some time for the background connection process to run
             tokio::time::sleep(Duration::from_millis(10)).await;
@@ -146,10 +143,7 @@ fn generate_messages(n_reqs: usize, msg_size: usize) -> Vec<Bytes> {
 fn pubsub_single_thread_tcp(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let buffer_size = 1024 * 64;
 
@@ -163,9 +157,7 @@ fn pubsub_single_thread_tcp(c: &mut Criterion) {
 
     let subscriber = SubSocket::with_options(
         Tcp::default(),
-        SubOptions::default()
-            .read_buffer_size(buffer_size)
-            .ingress_buffer_size(N_REQS * 2),
+        SubOptions::default().read_buffer_size(buffer_size).ingress_buffer_size(N_REQS * 2),
     );
 
     let mut bench = PairBenchmark {
@@ -190,11 +182,8 @@ fn pubsub_single_thread_tcp(c: &mut Criterion) {
 fn pubsub_multi_thread_tcp(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap();
 
     let buffer_size = 1024 * 64;
 
@@ -208,9 +197,7 @@ fn pubsub_multi_thread_tcp(c: &mut Criterion) {
 
     let subscriber = SubSocket::with_options(
         Tcp::default(),
-        SubOptions::default()
-            .read_buffer_size(buffer_size)
-            .ingress_buffer_size(N_REQS * 2),
+        SubOptions::default().read_buffer_size(buffer_size).ingress_buffer_size(N_REQS * 2),
     );
 
     let mut bench = PairBenchmark {
@@ -235,10 +222,7 @@ fn pubsub_multi_thread_tcp(c: &mut Criterion) {
 fn pubsub_single_thread_quic(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let buffer_size = 1024 * 64;
 
@@ -252,9 +236,7 @@ fn pubsub_single_thread_quic(c: &mut Criterion) {
 
     let subscriber = SubSocket::with_options(
         Quic::default(),
-        SubOptions::default()
-            .read_buffer_size(buffer_size)
-            .ingress_buffer_size(N_REQS * 2),
+        SubOptions::default().read_buffer_size(buffer_size).ingress_buffer_size(N_REQS * 2),
     );
 
     let mut bench = PairBenchmark {
@@ -279,11 +261,8 @@ fn pubsub_single_thread_quic(c: &mut Criterion) {
 fn pubsub_multi_thread_quic(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap();
 
     let buffer_size = 1024 * 64;
 
@@ -297,9 +276,7 @@ fn pubsub_multi_thread_quic(c: &mut Criterion) {
 
     let subscriber = SubSocket::with_options(
         Quic::default(),
-        SubOptions::default()
-            .read_buffer_size(buffer_size)
-            .ingress_buffer_size(N_REQS * 2),
+        SubOptions::default().read_buffer_size(buffer_size).ingress_buffer_size(N_REQS * 2),
     );
 
     let mut bench = PairBenchmark {
@@ -324,10 +301,7 @@ fn pubsub_multi_thread_quic(c: &mut Criterion) {
 fn pubsub_single_thread_ipc(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let buffer_size = 1024 * 64;
 
@@ -341,9 +315,7 @@ fn pubsub_single_thread_ipc(c: &mut Criterion) {
 
     let subscriber = SubSocket::with_options(
         Ipc::default(),
-        SubOptions::default()
-            .read_buffer_size(buffer_size)
-            .ingress_buffer_size(N_REQS * 2),
+        SubOptions::default().read_buffer_size(buffer_size).ingress_buffer_size(N_REQS * 2),
     );
 
     let mut bench = PairBenchmark {
@@ -368,11 +340,8 @@ fn pubsub_single_thread_ipc(c: &mut Criterion) {
 fn pubsub_multi_thread_ipc(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap();
 
     let buffer_size = 1024 * 64;
 
@@ -386,9 +355,7 @@ fn pubsub_multi_thread_ipc(c: &mut Criterion) {
 
     let subscriber = SubSocket::with_options(
         Ipc::default(),
-        SubOptions::default()
-            .read_buffer_size(buffer_size)
-            .ingress_buffer_size(N_REQS * 2),
+        SubOptions::default().read_buffer_size(buffer_size).ingress_buffer_size(N_REQS * 2),
     );
 
     let mut bench = PairBenchmark {

--- a/msg/benches/reqrep.rs
+++ b/msg/benches/reqrep.rs
@@ -39,10 +39,7 @@ impl<T: Transport<A> + Send + Sync + Unpin + 'static, A: Address> PairBenchmark<
         self.rt.block_on(async {
             rep.try_bind(vec![addr]).await.unwrap();
 
-            self.req
-                .try_connect(rep.local_addr().unwrap().clone())
-                .await
-                .unwrap();
+            self.req.try_connect(rep.local_addr().unwrap().clone()).await.unwrap();
 
             tokio::spawn(async move {
                 rep.map(|req| async move {
@@ -117,10 +114,7 @@ fn generate_requests(n_reqs: usize, msg_size: usize) -> Vec<Bytes> {
 fn reqrep_single_thread_tcp(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let req = ReqSocket::with_options(
         Tcp::default(),
@@ -150,11 +144,8 @@ fn reqrep_single_thread_tcp(c: &mut Criterion) {
 fn reqrep_multi_thread_tcp(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap();
 
     let req = ReqSocket::with_options(
         Tcp::default(),
@@ -184,10 +175,7 @@ fn reqrep_multi_thread_tcp(c: &mut Criterion) {
 fn reqrep_single_thread_ipc(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
 
     let req = ReqSocket::new(Ipc::default());
     let rep = RepSocket::new(Ipc::default());
@@ -213,11 +201,8 @@ fn reqrep_single_thread_ipc(c: &mut Criterion) {
 fn reqrep_multi_thread_ipc(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap();
 
     let req = ReqSocket::new(Ipc::default());
     let rep = RepSocket::new(Ipc::default());

--- a/msg/examples/durable.rs
+++ b/msg/examples/durable.rs
@@ -5,27 +5,27 @@ use tokio::sync::oneshot;
 use tokio_stream::StreamExt;
 
 use msg::{tcp::Tcp, Authenticator, RepSocket, ReqOptions, ReqSocket};
-use tracing::Instrument;
+use tracing::{error, info, info_span, instrument, warn, Instrument};
 
 #[derive(Default)]
 struct Auth;
 
 impl Authenticator for Auth {
     fn authenticate(&self, id: &Bytes) -> bool {
-        tracing::info!("Auth request from: {:?}, authentication passed.", id);
+        info!("Auth request from: {:?}, authentication passed.", id);
         // Custom authentication logic
         true
     }
 }
 
-#[tracing::instrument(name = "RepSocket")]
+#[instrument(name = "RepSocket")]
 async fn start_rep() {
     // Initialize the reply socket (server side) with a transport
     // and an authenticator.
     let mut rep = RepSocket::new(Tcp::default()).with_auth(Auth);
     while rep.bind("0.0.0.0:4444").await.is_err() {
         rep = RepSocket::new(Tcp::default()).with_auth(Auth);
-        tracing::warn!("Failed to bind rep socket, retrying...");
+        warn!("Failed to bind rep socket, retrying...");
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 
@@ -35,7 +35,7 @@ async fn start_rep() {
     loop {
         let req = rep.next().await.unwrap();
         n_reqs += 1;
-        tracing::info!("Message: {:?}", req.msg());
+        info!("Message: {:?}", req.msg());
 
         let msg = String::from_utf8_lossy(req.msg()).to_string();
         let msg_id = msg
@@ -46,7 +46,7 @@ async fn start_rep() {
             .unwrap();
 
         if n_reqs == 5 {
-            tracing::warn!(
+            warn!(
                 "RepSocket received the 5th request, dropping the request to trigger a timeout..."
             );
 
@@ -79,9 +79,9 @@ async fn main() {
             req.connect("0.0.0.0:4444").await.unwrap();
 
             for i in 0..10 {
-                tracing::info!("Sending request {i}...");
+                info!("Sending request {i}...");
                 if i == 0 {
-                    tracing::warn!("At this point the RepSocket is not running yet, so the request will block while \
+                    warn!("At this point the RepSocket is not running yet, so the request will block while \
                     the ReqSocket continues to establish a connection. The RepSocket will be started in 3 seconds.");
                 }
 
@@ -91,30 +91,30 @@ async fn main() {
                     match req.request(Bytes::from(msg.clone())).await {
                         Ok(res) => break res,
                         Err(e) => {
-                            tracing::error!("Request failed: {:?}, retrying...", e);
+                            error!("Request failed: {:?}, retrying...", e);
                             tokio::time::sleep(Duration::from_millis(1000)).await;
                         }
                     }
                 };
 
-                tracing::info!("Response: {:?}", res);
+                info!("Response: {:?}", res);
                 tokio::time::sleep(Duration::from_millis(1000)).await;
             }
 
             tx.send(true).unwrap();
         }
-        .instrument(tracing::info_span!("ReqSocket")),
+        .instrument(info_span!("ReqSocket")),
     );
 
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    tracing::info!("==========================");
-    tracing::info!("Starting the RepSocket now");
-    tracing::info!("==========================");
+    info!("==========================");
+    info!("Starting the RepSocket now");
+    info!("==========================");
 
     tokio::spawn(start_rep());
 
     // Wait for the client to finish
     rx.await.unwrap();
-    tracing::info!("DONE. Sent all 10 PINGS and received 10 PONGS.");
+    info!("DONE. Sent all 10 PINGS and received 10 PONGS.");
 }

--- a/msg/examples/durable.rs
+++ b/msg/examples/durable.rs
@@ -38,12 +38,7 @@ async fn start_rep() {
         info!("Message: {:?}", req.msg());
 
         let msg = String::from_utf8_lossy(req.msg()).to_string();
-        let msg_id = msg
-            .split_whitespace()
-            .nth(1)
-            .unwrap()
-            .parse::<i32>()
-            .unwrap();
+        let msg_id = msg.split_whitespace().nth(1).unwrap().parse::<i32>().unwrap();
 
         if n_reqs == 5 {
             warn!(
@@ -66,9 +61,7 @@ async fn main() {
     // and an identifier. This will implicitly turn on client authentication.
     let mut req = ReqSocket::with_options(
         Tcp::default(),
-        ReqOptions::default()
-            .timeout(Duration::from_secs(4))
-            .auth_token(Bytes::from("client1")),
+        ReqOptions::default().timeout(Duration::from_secs(4)).auth_token(Bytes::from("client1")),
     );
 
     let (tx, rx) = oneshot::channel();
@@ -91,7 +84,7 @@ async fn main() {
                     match req.request(Bytes::from(msg.clone())).await {
                         Ok(res) => break res,
                         Err(e) => {
-                            error!("Request failed: {:?}, retrying...", e);
+                            error!(err = ?e, "Request failed, retrying...");
                             tokio::time::sleep(Duration::from_millis(1000)).await;
                         }
                     }

--- a/msg/examples/pubsub.rs
+++ b/msg/examples/pubsub.rs
@@ -19,10 +19,8 @@ async fn main() {
     );
 
     // Configure the subscribers with options
-    let mut sub1 = SubSocket::with_options(
-        Tcp::default(),
-        SubOptions::default().ingress_buffer_size(1024),
-    );
+    let mut sub1 =
+        SubSocket::with_options(Tcp::default(), SubOptions::default().ingress_buffer_size(1024));
 
     let mut sub2 = SubSocket::with_options(
         // TCP transport with blocking connect, usually connection happens in the background.
@@ -49,8 +47,8 @@ async fn main() {
     let t1 = tokio::spawn(
         async move {
             loop {
-                // Wait for a message to arrive, or timeout after 2 seconds. If the unsubscription was succesful,
-                // we should time out after the 10th message.
+                // Wait for a message to arrive, or timeout after 2 seconds. If the unsubscription
+                // was succesful, we should time out after the 10th message.
                 let Ok(Some(recv)) = timeout(Duration::from_millis(2000), sub1.next()).await else {
                     warn!("Timeout waiting for message, stopping sub1");
                     break;
@@ -83,10 +81,7 @@ async fn main() {
 
     for i in 0..20 {
         tokio::time::sleep(Duration::from_millis(300)).await;
-        pub_socket
-            .publish("HELLO_TOPIC".to_string(), format!("Message {i}").into())
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO_TOPIC".to_string(), format!("Message {i}").into()).await.unwrap();
     }
 
     let _ = tokio::join!(t1, t2);

--- a/msg/examples/pubsub.rs
+++ b/msg/examples/pubsub.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use std::time::Duration;
 use tokio::time::timeout;
-use tracing::Instrument;
+use tracing::{info, info_span, warn, Instrument};
 
 use msg::{tcp::Tcp, PubOptions, PubSocket, SubOptions, SubSocket};
 
@@ -34,17 +34,17 @@ async fn main() {
     pub_socket.bind("127.0.0.1:0").await.unwrap();
     let pub_addr = pub_socket.local_addr().unwrap();
 
-    tracing::info!("Publisher listening on: {}", pub_addr);
+    info!("Publisher listening on: {}", pub_addr);
 
     sub1.connect(pub_addr).await.unwrap();
 
     sub1.subscribe("HELLO_TOPIC".to_string()).await.unwrap();
-    tracing::info!("Subscriber 1 connected and subscribed to HELLO_TOPIC");
+    info!("Subscriber 1 connected and subscribed to HELLO_TOPIC");
 
     sub2.connect(pub_addr).await.unwrap();
 
     sub2.subscribe("HELLO_TOPIC".to_string()).await.unwrap();
-    tracing::info!("Subscriber 2 connected and subscribed to HELLO_TOPIC");
+    info!("Subscriber 2 connected and subscribed to HELLO_TOPIC");
 
     let t1 = tokio::spawn(
         async move {
@@ -52,33 +52,33 @@ async fn main() {
                 // Wait for a message to arrive, or timeout after 2 seconds. If the unsubscription was succesful,
                 // we should time out after the 10th message.
                 let Ok(Some(recv)) = timeout(Duration::from_millis(2000), sub1.next()).await else {
-                    tracing::warn!("Timeout waiting for message, stopping sub1");
+                    warn!("Timeout waiting for message, stopping sub1");
                     break;
                 };
 
                 let string = bytes_to_string(recv.clone().into_payload());
-                tracing::info!("Received message: {}", string);
+                info!("Received message: {}", string);
                 if string.contains("10") {
-                    tracing::warn!("Received message 10, unsubscribing...");
+                    warn!("Received message 10, unsubscribing...");
                     sub1.unsubscribe("HELLO_TOPIC".to_string()).await.unwrap();
                 }
             }
         }
-        .instrument(tracing::info_span!("sub1")),
+        .instrument(info_span!("sub1")),
     );
 
     let t2 = tokio::spawn(
         async move {
             loop {
                 let Ok(Some(recv)) = timeout(Duration::from_millis(1000), sub2.next()).await else {
-                    tracing::warn!("Timeout waiting for message, stopping sub2");
+                    warn!("Timeout waiting for message, stopping sub2");
                     break;
                 };
                 let string = bytes_to_string(recv.clone().into_payload());
-                tracing::info!("Received message: {}", string);
+                info!("Received message: {}", string);
             }
         }
-        .instrument(tracing::info_span!("sub2")),
+        .instrument(info_span!("sub2")),
     );
 
     for i in 0..20 {

--- a/msg/examples/pubsub_auth.rs
+++ b/msg/examples/pubsub_auth.rs
@@ -3,7 +3,7 @@ use futures::StreamExt;
 use msg_socket::SubOptions;
 use std::time::Duration;
 use tokio::time::timeout;
-use tracing::Instrument;
+use tracing::{info, info_span, warn, Instrument};
 
 use msg::{tcp::Tcp, Authenticator, PubSocket, SubSocket};
 
@@ -12,12 +12,12 @@ struct Auth;
 
 impl Authenticator for Auth {
     fn authenticate(&self, id: &Bytes) -> bool {
-        tracing::info!("Auth request from: {:?}", id);
+        info!("Auth request from: {:?}", id);
         if id.as_ref() == b"client1" {
-            tracing::info!("Client authenticated: {:?}", id);
+            info!("Client authenticated: {:?}", id);
             true
         } else {
-            tracing::warn!("Unknown client: {:?}", id);
+            warn!("Unknown client: {:?}", id);
             false
         }
     }
@@ -48,17 +48,17 @@ async fn main() {
     pub_socket.bind("127.0.0.1:0").await.unwrap();
 
     let pub_addr = pub_socket.local_addr().unwrap();
-    tracing::info!("Publisher listening on: {}", pub_addr);
+    info!("Publisher listening on: {}", pub_addr);
 
     sub1.connect(pub_addr).await.unwrap();
 
     sub1.subscribe("HELLO_TOPIC".to_string()).await.unwrap();
-    tracing::info!("Subscriber 1 connected and subscribed to HELLO_TOPIC");
+    info!("Subscriber 1 connected and subscribed to HELLO_TOPIC");
 
     sub2.connect(pub_addr).await.unwrap();
 
     sub2.subscribe("HELLO_TOPIC".to_string()).await.unwrap();
-    tracing::info!("Subscriber 2 connected and subscribed to HELLO_TOPIC");
+    info!("Subscriber 2 connected and subscribed to HELLO_TOPIC");
 
     let t1 = tokio::spawn(
         async move {
@@ -66,33 +66,33 @@ async fn main() {
                 // Wait for a message to arrive, or timeout after 2 seconds. If the unsubscription was succesful,
                 // we should time out after the 10th message.
                 let Ok(Some(recv)) = timeout(Duration::from_millis(2000), sub1.next()).await else {
-                    tracing::warn!("Timeout waiting for message, stopping sub1");
+                    warn!("Timeout waiting for message, stopping sub1");
                     break;
                 };
 
                 let string = bytes_to_string(recv.clone().into_payload());
-                tracing::info!("Received message: {}", string);
+                info!("Received message: {}", string);
                 if string.contains("10") {
-                    tracing::warn!("Received message 10, unsubscribing...");
+                    warn!("Received message 10, unsubscribing...");
                     sub1.unsubscribe("HELLO_TOPIC".to_string()).await.unwrap();
                 }
             }
         }
-        .instrument(tracing::info_span!("sub1")),
+        .instrument(info_span!("sub1")),
     );
 
     let t2 = tokio::spawn(
         async move {
             loop {
                 let Ok(Some(recv)) = timeout(Duration::from_millis(1000), sub2.next()).await else {
-                    tracing::warn!("Timeout waiting for message, stopping sub2");
+                    warn!("Timeout waiting for message, stopping sub2");
                     break;
                 };
                 let string = bytes_to_string(recv.clone().into_payload());
-                tracing::info!("Received message: {}", string);
+                info!("Received message: {}", string);
             }
         }
-        .instrument(tracing::info_span!("sub2")),
+        .instrument(info_span!("sub2")),
     );
 
     for i in 0..20 {

--- a/msg/examples/pubsub_auth.rs
+++ b/msg/examples/pubsub_auth.rs
@@ -63,8 +63,8 @@ async fn main() {
     let t1 = tokio::spawn(
         async move {
             loop {
-                // Wait for a message to arrive, or timeout after 2 seconds. If the unsubscription was succesful,
-                // we should time out after the 10th message.
+                // Wait for a message to arrive, or timeout after 2 seconds. If the unsubscription
+                // was succesful, we should time out after the 10th message.
                 let Ok(Some(recv)) = timeout(Duration::from_millis(2000), sub1.next()).await else {
                     warn!("Timeout waiting for message, stopping sub1");
                     break;
@@ -97,10 +97,7 @@ async fn main() {
 
     for i in 0..20 {
         tokio::time::sleep(Duration::from_millis(300)).await;
-        pub_socket
-            .publish("HELLO_TOPIC".to_string(), format!("Message {i}").into())
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO_TOPIC".to_string(), format!("Message {i}").into()).await.unwrap();
     }
 
     let _ = tokio::join!(t1, t2);

--- a/msg/examples/pubsub_compression.rs
+++ b/msg/examples/pubsub_compression.rs
@@ -39,8 +39,8 @@ async fn main() {
     let t1 = tokio::spawn(
         async move {
             loop {
-                // Wait for a message to arrive, or timeout after 2 seconds. If the unsubscription was succesful,
-                // we should time out after the 10th message.
+                // Wait for a message to arrive, or timeout after 2 seconds. If the unsubscription
+                // was succesful, we should time out after the 10th message.
                 let Ok(Some(recv)) = timeout(Duration::from_millis(2000), sub1.next()).await else {
                     warn!("Timeout waiting for message, stopping sub1");
                     break;
@@ -73,10 +73,7 @@ async fn main() {
 
     for i in 0..20 {
         tokio::time::sleep(Duration::from_millis(300)).await;
-        pub_socket
-            .publish("HELLO_TOPIC".to_string(), format!("Message {i}").into())
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO_TOPIC".to_string(), format!("Message {i}").into()).await.unwrap();
     }
 
     let _ = tokio::join!(t1, t2);

--- a/msg/examples/quic_vs_tcp.rs
+++ b/msg/examples/quic_vs_tcp.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use msg_transport::{quic::Quic, Transport};
 use std::time::{Duration, Instant};
+use tracing::info;
 
 use msg::{tcp::Tcp, Address, PubOptions, PubSocket, SubOptions, SubSocket};
 
@@ -33,12 +34,12 @@ async fn run_tcp() {
     pub_socket.bind("127.0.0.1:0").await.unwrap();
     let pub_addr = pub_socket.local_addr().unwrap();
 
-    tracing::info!("Publisher listening on: {}", pub_addr);
+    info!("Publisher listening on: {}", pub_addr);
 
     sub1.connect(pub_addr).await.unwrap();
 
     sub1.subscribe("HELLO_TOPIC".to_string()).await.unwrap();
-    tracing::info!("Subscriber 1 connected and subscribed to HELLO_TOPIC");
+    info!("Subscriber 1 connected and subscribed to HELLO_TOPIC");
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
@@ -66,12 +67,12 @@ async fn run_quic() {
     pub_socket.bind("127.0.0.1:0").await.unwrap();
     let pub_addr = pub_socket.local_addr().unwrap();
 
-    tracing::info!("Publisher listening on: {}", pub_addr);
+    info!("Publisher listening on: {}", pub_addr);
 
     sub1.connect(pub_addr).await.unwrap();
 
     sub1.subscribe("HELLO_TOPIC".to_string()).await.unwrap();
-    tracing::info!("Subscriber 1 connected and subscribed to HELLO_TOPIC");
+    info!("Subscriber 1 connected and subscribed to HELLO_TOPIC");
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
@@ -97,7 +98,7 @@ async fn run_transfer<T: Transport<A> + Send + Unpin + 'static, A: Address>(
 
         let recv = sub_socket.next().await.unwrap();
         let elapsed = start.elapsed();
-        tracing::info!("{} transfer took {:?}", transport, elapsed);
+        info!("{} transfer took {:?}", transport, elapsed);
         assert_eq!(recv.into_payload(), data);
 
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/msg/examples/quic_vs_tcp.rs
+++ b/msg/examples/quic_vs_tcp.rs
@@ -25,10 +25,8 @@ async fn run_tcp() {
     );
 
     // Configure the subscribers with options
-    let mut sub1 = SubSocket::with_options(
-        Tcp::default(),
-        SubOptions::default().ingress_buffer_size(1024),
-    );
+    let mut sub1 =
+        SubSocket::with_options(Tcp::default(), SubOptions::default().ingress_buffer_size(1024));
 
     tracing::info!("Setting up the sockets...");
     pub_socket.bind("127.0.0.1:0").await.unwrap();
@@ -91,10 +89,7 @@ async fn run_transfer<T: Transport<A> + Send + Unpin + 'static, A: Address>(
 
     for _ in 0..100 {
         let start = Instant::now();
-        pub_socket
-            .publish("HELLO_TOPIC".to_string(), data.clone())
-            .await
-            .unwrap();
+        pub_socket.publish("HELLO_TOPIC".to_string(), data.clone()).await.unwrap();
 
         let recv = sub_socket.next().await.unwrap();
         let elapsed = start.elapsed();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,11 @@
+reorder_imports = true
+imports_granularity = "Crate"
+use_small_heuristics = "Max"
+comment_width = 100
+wrap_comments = true
+binop_separator = "Back"
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true
+format_code_in_doc_comments = true
+doc_comment_code_block_width = 100


### PR DESCRIPTION
A maintenance refactor. No functionality changed.

* added new `rustfmt` rules, most of these diffs are generated by cargo fmt.
* formatted errors
* use `tracing` at top level
* overall small improvements in readability
* added some docs
