### PR TITLE
feat: bump MSRV + minor refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "msg"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "criterion",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "msg-common"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "futures",
  "tokio",
@@ -742,14 +742,14 @@ dependencies = [
 
 [[package]]
 name = "msg-sim"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "pnet",
 ]
 
 [[package]]
 name = "msg-socket"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "futures",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "msg-transport"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "msg-wire"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.75"
 license = "MIT"
 description = "A flexible and lightweight messaging library for distributed systems"
 authors = ["Jonas Bostoen", "Nicolas Racchi"]
@@ -72,3 +72,88 @@ opt-level = 3
 [profile.debug-maxperf]
 inherits = "maxperf"
 debug = true
+
+[workspace.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[workspace.lints.rustdoc]
+all = "warn"
+
+[workspace.lints.rust]
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+rust-2018-idioms = { level = "deny", priority = -1 }
+unreachable-pub = "warn"
+unused-must-use = "deny"
+
+[workspace.lints.clippy]
+# These are some of clippy's nursery (i.e., experimental) lints that we like.
+# By default, nursery lints are allowed. Some of the lints below have made good
+# suggestions which we fixed. The others didn't have any findings, so we can
+# assume they don't have that many false positives. Let's enable them to
+# prevent future problems.
+branches_sharing_code = "warn"
+clear_with_drain = "warn"
+derive_partial_eq_without_eq = "warn"
+doc_markdown = "warn"
+empty_line_after_doc_comments = "warn"
+empty_line_after_outer_attr = "warn"
+enum_glob_use = "warn"
+equatable_if_let = "warn"
+explicit_into_iter_loop = "warn"
+explicit_iter_loop = "warn"
+flat_map_option = "warn"
+imprecise_flops = "warn"
+iter_on_empty_collections = "warn"
+iter_on_single_items = "warn"
+iter_with_drain = "warn"
+iter_without_into_iter = "warn"
+large_stack_frames = "warn"
+manual_assert = "warn"
+manual_clamp = "warn"
+manual_string_new = "warn"
+match_same_arms = "warn"
+missing_const_for_fn = "warn"
+mutex_integer = "warn"
+naive_bytecount = "warn"
+needless_bitwise_bool = "warn"
+needless_continue = "warn"
+needless_pass_by_ref_mut = "warn"
+nonstandard_macro_braces = "warn"
+or_fun_call = "warn"
+path_buf_push_overwrite = "warn"
+read_zero_byte_vec = "warn"
+redundant_clone = "warn"
+single_char_pattern = "warn"
+string_lit_as_bytes = "warn"
+suboptimal_flops = "warn"
+suspicious_operation_groupings = "warn"
+trailing_empty_array = "warn"
+trait_duplication_in_bounds = "warn"
+transmute_undefined_repr = "warn"
+trivial_regex = "warn"
+tuple_array_conversions = "warn"
+type_repetition_in_bounds = "warn"
+uninhabited_references = "warn"
+unnecessary_struct_initialization = "warn"
+unused_peekable = "warn"
+unused_rounding = "warn"
+use_self = "warn"
+useless_let_if_seq = "warn"
+zero_sized_map_values = "warn"
+
+# These are nursery lints which have findings. Allow them for now. Some are not
+# quite mature enough for use in our codebase and some we don't really want.
+# Explicitly listing should make it easier to fix in the future.
+as_ptr_cast_mut = "allow"
+cognitive_complexity = "allow"
+collection_is_never_read = "allow"
+debug_assert_with_mut_call = "allow"
+fallible_impl_from = "allow"
+future_not_send = "allow"
+needless_collect = "allow"
+non_send_fields_in_send_ty = "allow"
+redundant_pub_crate = "allow"
+significant_drop_in_scrutinee = "allow"
+significant_drop_tightening = "allow"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The 📖 [MSG-RS Book][book] contains detailed information on how to use the lib
 
 ## MSRV
 
-The minimum supported Rust version is 1.70.
+The minimum supported Rust version is 1.75.
 
 ## Contributions & Bug Reports
 

--- a/book/src/usage/faq.md
+++ b/book/src/usage/faq.md
@@ -15,4 +15,4 @@ Until then, we recommend using the git dependency as shown in the [Getting start
 
 ## What is the minimum supported Rust version (MSRV)?
 
-MSG-RS currently supports Rust 1.70 or later.
+MSG-RS currently supports Rust 1.75 or later.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+default: check doc fmt
+
+check:
+    cargo check --workspace --all-features --all-targets
+
+doc:
+    cargo doc --workspace --all-features --no-deps --document-private-items
+
+
+fmt:
+    cargo +nightly fmt --all -- --check
+
+test:
+    cargo nextest run --workspace --retries 3

--- a/msg-common/src/channel.rs
+++ b/msg-common/src/channel.rs
@@ -56,11 +56,11 @@ impl<S: Send + 'static, R> Channel<S, R> {
         self.tx.send(msg).await
     }
 
-    /// Attempts to immediately send a message on this [`Sender`]
+    /// Attempts to immediately send a message on this channel.
     ///
-    /// This method differs from [`send`] by returning immediately if the channel's
+    /// This method differs from `send` by returning immediately if the channel's
     /// buffer is full or no receiver is waiting to acquire some data. Compared
-    /// with [`send`], this function has two failure cases instead of one (one for
+    /// with `send`, this function has two failure cases instead of one (one for
     /// disconnection, one for a full buffer).
     pub fn try_send(&mut self, msg: S) -> Result<(), TrySendError<S>> {
         if let Some(tx) = self.tx.get_ref() {
@@ -70,17 +70,17 @@ impl<S: Send + 'static, R> Channel<S, R> {
         }
     }
 
-    /// Receives the next value for this receiver.
+    /// Receives the next value for this channel.
     ///
     /// This method returns `None` if the channel has been closed and there are
     /// no remaining messages in the channel's buffer. This indicates that no
     /// further values can ever be received from this `Receiver`. The channel is
-    /// closed when all senders have been dropped, or when [`close`] is called.
+    /// closed when all senders have been dropped, or when `close` is called.
     ///
     /// If there are no messages in the channel's buffer, but the channel has
     /// not yet been closed, this method will sleep until a message is sent or
-    /// the channel is closed.  Note that if [`close`] is called, but there are
-    /// still outstanding [`Permits`] from before it was closed, the channel is
+    /// the channel is closed.  Note that if `close` is called, but there are
+    /// still outstanding `Permits` from before it was closed, the channel is
     /// not considered closed by `recv` until the permits are released.
     pub async fn recv(&mut self) -> Option<R> {
         self.rx.recv().await
@@ -89,10 +89,10 @@ impl<S: Send + 'static, R> Channel<S, R> {
     /// Tries to receive the next value for this receiver.
     ///
     /// This method returns the [`Empty`](TryRecvError::Empty) error if the channel is currently
-    /// empty, but there are still outstanding [senders] or [permits].
+    /// empty, but there are still outstanding senders or permits.
     ///
     /// This method returns the [`Disconnected`](TryRecvError::Disconnected) error if the channel is
-    /// currently empty, and there are no outstanding [senders] or [permits].
+    /// currently empty, and there are no outstanding senders or permits.
     ///
     /// Unlike the [`poll_recv`](Self::poll_recv) method, this method will never return an
     /// [`Empty`](TryRecvError::Empty) error spuriously.

--- a/msg-sim/src/dummynet.rs
+++ b/msg-sim/src/dummynet.rs
@@ -271,13 +271,13 @@ fn get_loopback_name() -> String {
 }
 
 /// Assert that the given status is successful, otherwise return an error with the given message.
-/// The type of the error will be `io::ErrorKind::Other`.
+/// The type of the error will be [`io::ErrorKind::Other`].
 fn assert_status<E>(status: ExitStatus, error: E) -> io::Result<()>
 where
     E: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     if !status.success() {
-        return Err(io::Error::new(io::ErrorKind::Other, error));
+        return Err(io::Error::other(error));
     }
 
     Ok(())

--- a/msg-socket/src/lib.rs
+++ b/msg-socket/src/lib.rs
@@ -2,24 +2,31 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use msg_transport::Address;
+use bytes::Bytes;
 use tokio::io::{AsyncRead, AsyncWrite};
+
+use msg_transport::Address;
 
 #[path = "pub/mod.rs"]
 mod pubs;
+pub use pubs::{PubError, PubOptions, PubSocket};
+
 mod rep;
+pub use rep::*;
+
 mod req;
+pub use req::*;
+
 mod sub;
+pub use sub::*;
 
 mod connection;
 pub use connection::*;
 
-use bytes::Bytes;
-pub use pubs::{PubError, PubOptions, PubSocket};
-pub use rep::*;
-pub use req::*;
-pub use sub::*;
+/// The default buffer size for a socket.
+const DEFAULT_BUFFER_SIZE: usize = 1024;
 
+/// A request Identifier.
 pub struct RequestId(u32);
 
 impl RequestId {
@@ -36,10 +43,12 @@ impl RequestId {
     }
 }
 
+/// An interface for authenticating clients, given their ID.
 pub trait Authenticator: Send + Sync + Unpin + 'static {
     fn authenticate(&self, id: &Bytes) -> bool;
 }
 
+/// The result of an authentication attempt.
 pub(crate) struct AuthResult<S: AsyncRead + AsyncWrite, A: Address> {
     id: Bytes,
     addr: A,

--- a/msg-socket/src/pub/driver.rs
+++ b/msg-socket/src/pub/driver.rs
@@ -17,7 +17,8 @@ use crate::{AuthResult, Authenticator};
 use msg_transport::{Address, PeerAddress, Transport};
 use msg_wire::{auth, pubsub};
 
-#[allow(clippy::type_complexity)]
+/// The driver for the publisher socket. This is responsible for accepting incoming connections,
+/// authenticating them, and spawning new [`SubscriberSession`]s for each connection.
 pub(crate) struct PubDriver<T: Transport<A>, A: Address> {
     /// Session ID counter.
     pub(super) id_counter: u32,

--- a/msg-socket/src/pub/stats.rs
+++ b/msg-socket/src/pub/stats.rs
@@ -8,8 +8,6 @@ pub struct SocketStats {
     bytes_tx: AtomicUsize,
     /// Total number of active request clients
     active_clients: AtomicUsize,
-    // / Total number of dropped messages due to a slow consumer
-    // dropped_messages: AtomicUsize,
 }
 
 impl SocketStats {

--- a/msg-socket/src/pub/trie.rs
+++ b/msg-socket/src/pub/trie.rs
@@ -2,6 +2,7 @@ use std::collections::hash_map::Entry;
 
 use rustc_hash::FxHashMap;
 
+/// A node in the prefix trie.
 struct Node {
     children: FxHashMap<String, Node>,
     catch_all: bool,
@@ -14,6 +15,11 @@ impl Node {
     }
 }
 
+/// A prefix trie for matching topics.
+///
+/// This trie is used to match topics in a NATS-like system. It supports wildcards:
+/// - `*` matches a single token.
+/// - `>` matches one or more tokens.
 pub(super) struct PrefixTrie {
     root: Node,
 }

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -9,10 +9,9 @@ mod stats;
 pub use socket::*;
 use stats::SocketStats;
 
-const DEFAULT_BUFFER_SIZE: usize = 1024;
-
+/// Errors that can occur when using a reply socket.
 #[derive(Debug, Error)]
-pub enum PubError {
+pub enum RepError {
     #[error("IO error: {0:?}")]
     Io(#[from] std::io::Error),
     #[error("Wire protocol error: {0:?}")]
@@ -21,10 +20,11 @@ pub enum PubError {
     Auth(String),
     #[error("Socket closed")]
     SocketClosed,
-    #[error("Transport error: {0:?}")]
-    Transport(#[from] Box<dyn std::error::Error + Send + Sync>),
+    #[error("Could not connect to any valid endpoints")]
+    NoValidEndpoints,
 }
 
+/// The reply socket options.
 pub struct RepOptions {
     /// The maximum number of concurrent clients.
     max_clients: Option<usize>,
@@ -82,8 +82,8 @@ impl<A: Address> Request<A> {
     }
 
     /// Responds to the request.
-    pub fn respond(self, response: Bytes) -> Result<(), PubError> {
-        self.response.send(response).map_err(|_| PubError::SocketClosed)
+    pub fn respond(self, response: Bytes) -> Result<(), RepError> {
+        self.response.send(response).map_err(|_| RepError::SocketClosed)
     }
 }
 

--- a/msg-socket/src/rep/stats.rs
+++ b/msg-socket/src/rep/stats.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Statistics for a reply socket. These are shared between the driver task
-/// and the socket.
+/// Statistics for a reply socket.
+/// These are shared between the driver task and the socket.
 #[derive(Debug, Default)]
 pub struct SocketStats {
     /// Total bytes sent

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use rustc_hash::FxHashMap;
-use std::{io, marker::PhantomData, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{marker::PhantomData, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{
     net::{lookup_host, ToSocketAddrs},
     sync::{mpsc, oneshot},
@@ -40,9 +40,7 @@ where
     /// Connects to the target address with the default options.
     pub async fn connect(&mut self, addr: impl ToSocketAddrs) -> Result<(), ReqError> {
         let mut addrs = lookup_host(addr).await?;
-        let endpoint = addrs.next().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "could not find any valid address")
-        })?;
+        let endpoint = addrs.next().ok_or_else(|| ReqError::NoValidEndpoints)?;
 
         self.try_connect(endpoint).await
     }

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -19,13 +19,13 @@ mod stream;
 use msg_transport::Address;
 use msg_wire::pubsub;
 
-const DEFAULT_BUFFER_SIZE: usize = 1024;
+use crate::DEFAULT_BUFFER_SIZE;
 
 #[derive(Debug, Error)]
 pub enum SubError {
     #[error("IO error: {0:?}")]
     Io(#[from] std::io::Error),
-    #[error("Authentication error: {0:?}")]
+    #[error("Authentication error: {0}")]
     Auth(String),
     #[error("Wire protocol error: {0:?}")]
     Wire(#[from] pubsub::Error),
@@ -33,8 +33,10 @@ pub enum SubError {
     SocketClosed,
     #[error("Command channel full")]
     ChannelFull,
-    #[error("Transport error: {0:?}")]
-    Transport(#[from] Box<dyn std::error::Error + Send + Sync>),
+    #[error("Could not find any valid endpoints")]
+    NoValidEndpoints,
+    #[error("Reserved topic 'MSG' cannot be used")]
+    ReservedTopic,
 }
 
 #[derive(Debug)]

--- a/msg-socket/src/sub/stream.rs
+++ b/msg-socket/src/sub/stream.rs
@@ -1,14 +1,16 @@
-use bytes::Bytes;
-use futures::{SinkExt, Stream, StreamExt};
 use std::{
     pin::Pin,
     task::{ready, Context, Poll},
 };
+
+use bytes::Bytes;
+use futures::{SinkExt, Stream, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 use tracing::{debug, trace};
 
 use super::SubError;
+
 use msg_wire::pubsub;
 
 /// Wraps a framed connection to a publisher and exposes all the PUBSUB specific methods.
@@ -19,8 +21,7 @@ pub(super) struct PublisherStream<Io> {
 
 impl<Io: AsyncRead + AsyncWrite + Unpin> PublisherStream<Io> {
     /// Queues a message to be sent to the publisher. If the connection
-    /// is ready, this will register the waker
-    /// and flush on the next poll.
+    /// is ready, this will register the waker and flush on the next poll.
     pub fn poll_send(
         &mut self,
         cx: &mut Context<'_>,
@@ -48,6 +49,7 @@ impl<Io: AsyncRead + AsyncWrite + Unpin> From<Framed<Io, pubsub::Codec>> for Pub
     }
 }
 
+/// A message received from a stream.
 pub(super) struct TopicMessage {
     pub timestamp: u64,
     pub compression_type: u8,
@@ -58,7 +60,6 @@ pub(super) struct TopicMessage {
 impl<Io: AsyncRead + AsyncWrite + Unpin> Stream for PublisherStream<Io> {
     type Item = Result<TopicMessage, pubsub::Error>;
 
-    #[inline]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 

--- a/msg-transport/src/ipc/mod.rs
+++ b/msg-transport/src/ipc/mod.rs
@@ -109,10 +109,10 @@ impl Transport<PathBuf> for Ipc {
         if addr.exists() {
             debug!("Socket file already exists. Attempting to remove.");
             if let Err(e) = std::fs::remove_file(&addr) {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed to remove existing socket file, {:?}", e),
-                ));
+                return Err(io::Error::other(format!(
+                    "Failed to remove existing socket file, {:?}",
+                    e
+                )));
             }
         }
 

--- a/msg-transport/src/lib.rs
+++ b/msg-transport/src/lib.rs
@@ -45,12 +45,11 @@ pub trait Transport<A: Address> {
     /// An error that occurred when setting up the connection.
     type Error: std::error::Error + From<io::Error> + Send + Sync;
 
-    /// A pending [`Transport::Output`] for an outbound connection,
-    /// obtained when calling [`Transport::connect`].
+    /// A pending output for an outbound connection, obtained when calling [`Transport::connect`].
     type Connect: Future<Output = Result<Self::Io, Self::Error>> + Send;
 
-    /// A pending [`Transport::Output`] for an inbound connection,
-    /// obtained when calling [`Transport::poll_accept`].
+    /// A pending output for an inbound connection, obtained when calling
+    /// [`Transport::poll_accept`].
     type Accept: Future<Output = Result<Self::Io, Self::Error>> + Send + Unpin;
 
     /// Returns the local address this transport is bound to (if it is bound).
@@ -64,7 +63,7 @@ pub trait Transport<A: Address> {
     fn connect(&mut self, addr: A) -> Self::Connect;
 
     /// Poll for incoming connections. If an inbound connection is received, a future representing
-    /// a pending inbound connection is returned. The future will resolve to [`Transport::Output`].
+    /// a pending inbound connection is returned. The future will resolve to [`Transport::Accept`].
     fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Accept>;
 }
 

--- a/msg-wire/src/compression/mod.rs
+++ b/msg-wire/src/compression/mod.rs
@@ -2,12 +2,15 @@ use bytes::Bytes;
 use std::io;
 
 mod gzip;
-mod lz4;
-mod snappy;
-mod zstd;
 pub use gzip::*;
+
+mod lz4;
 pub use lz4::*;
+
+mod snappy;
 pub use snappy::*;
+
+mod zstd;
 pub use zstd::*;
 
 /// The possible compression type used for a message.

--- a/msg-wire/src/reqrep.rs
+++ b/msg-wire/src/reqrep.rs
@@ -11,10 +11,13 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("Invalid wire ID: {0}")]
     WireId(u8),
+    #[error("Failed to decompress message")]
+    Decompression,
 }
 
 #[derive(Debug, Clone)]
 pub struct Message {
+    /// The message header.
     header: Header,
     /// The message payload.
     payload: Bytes,

--- a/msg/Cargo.toml
+++ b/msg/Cargo.toml
@@ -16,21 +16,21 @@ msg-transport.workspace = true
 msg-wire.workspace = true
 
 tokio.workspace = true
-bytes.workspace = true
 tokio-stream.workspace = true
 
 [dev-dependencies]
-# benchmarking
+bytes.workspace = true
 tracing-subscriber = "0.3"
-# Add jemalloc for extra perf on Linux systems.
-[target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
-jemallocator = { version = "0.5.0", features = ["profiling"] }
 divan = "0.1"
 futures.workspace = true
 tracing.workspace = true
 rand.workspace = true
 criterion.workspace = true
 pprof.workspace = true
+
+# Add jemalloc for extra perf on Linux systems.
+[target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
+jemallocator = { version = "0.5.0", features = ["profiling"] }
 
 [[bench]]
 name = "reqrep"


### PR DESCRIPTION
This is a maintenance minor release.

* Bumped MSRV to 1.75
* Added missing documentation items and fixed inline docs with `cargo doc`
* Added stricter rules for crates to be more stable long-term
* Added some Error variants where `std::io::Error::Other` was used
* Other minor refactoring across the msg-socket crate