### PR TITLE
Fix: Update TCP usage examples

### DIFF
--- a/book/src/usage/authentication.md
+++ b/book/src/usage/authentication.md
@@ -26,7 +26,7 @@ client-server application:
 
 ```rust
 use msg::{
-    tcp::{self, Tcp},
+    tcp::{self, tcp::Tcp},
     Authenticator, ReqSocket, RepSocket,
 };
 

--- a/book/src/usage/compression.md
+++ b/book/src/usage/compression.md
@@ -18,7 +18,7 @@ In MSG, compression is handled by the socket type:
 You can also find a complete example in [msg/examples/reqrep_compression.rs][examples].
 
 ```rust
-use msg::{compression::GzipCompressor, ReqSocket, RepSocket, Tcp};
+use msg::{compression::GzipCompressor, ReqSocket, RepSocket, tcp::Tcp};
 
 #[tokio::main]
 async fn main() {
@@ -47,7 +47,7 @@ async fn main() {
 You can also find a complete example in [msg/examples/pubsub_compression.rs][examples].
 
 ```rust
-use msg::{compression::GzipCompressor, PubSocket, SubSocket, Tcp};
+use msg::{compression::GzipCompressor, PubSocket, SubSocket, tcp::Tcp};
 
 #[tokio::main]
 async fn main() {

--- a/book/src/usage/socket-types.md
+++ b/book/src/usage/socket-types.md
@@ -20,7 +20,7 @@ Example:
 use bytes::Bytes;
 use tokio_stream::StreamExt;
 
-use msg::{RepSocket, ReqSocket, Tcp};
+use msg::{RepSocket, ReqSocket, tcp::Tcp};
 
 #[tokio::main]
 async fn main() {
@@ -59,7 +59,7 @@ Example:
 use bytes::Bytes;
 use tokio_stream::StreamExt;
 
-use msg::{PubSocket, SubSocket, Tcp};
+use msg::{PubSocket, SubSocket, tcp::Tcp};
 
 #[tokio::main]
 async fn main() {

--- a/book/src/usage/transport-layers.md
+++ b/book/src/usage/transport-layers.md
@@ -32,7 +32,7 @@ be lost or corrupted.
 In MSG, here is how you can setup any socket type with the TCP transport:
 
 ```rust
-use msg::{RepSocket, ReqSocket, Tcp};
+use msg::{RepSocket, ReqSocket, tcp::Tcp};
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
I started using the lib, Nice one guys!
The tcp mod structure has changed but examples using old impl 
Before: `use msg::Tcp`
Now: `use msg::tcp::Tcp`

CC: @mempirate @merklefruit 