### PR TITLE
feat(sub): add socket-wide stats including dropped messages

### DIFF
--- a/msg-socket/src/lib.rs
+++ b/msg-socket/src/lib.rs
@@ -7,6 +7,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use msg_transport::Address;
 
+pub mod stats;
+
 #[path = "pub/mod.rs"]
 mod pubs;
 pub use pubs::{PubError, PubOptions, PubSocket};

--- a/msg-socket/src/pub/driver.rs
+++ b/msg-socket/src/pub/driver.rs
@@ -79,7 +79,7 @@ where
                     }
                     Err(e) => {
                         error!(err = ?e, "Error authenticating client");
-                        this.state.stats.decrement_active_clients();
+                        this.state.stats.specific.decrement_active_clients();
                     }
                 }
 
@@ -93,7 +93,7 @@ where
                     Ok(io) => {
                         if let Err(e) = this.on_incoming(io) {
                             error!(err = ?e, "Error accepting incoming connection");
-                            this.state.stats.decrement_active_clients();
+                            this.state.stats.specific.decrement_active_clients();
                         }
                     }
                     Err(e) => {
@@ -101,7 +101,7 @@ where
 
                         // Active clients have already been incremented in the initial call to
                         // `poll_accept`, so we need to decrement them here.
-                        this.state.stats.decrement_active_clients();
+                        this.state.stats.specific.decrement_active_clients();
                     }
                 }
 
@@ -112,7 +112,7 @@ where
             // incoming connection tasks.
             if let Poll::Ready(accept) = Pin::new(&mut this.transport).poll_accept(cx) {
                 if let Some(max) = this.options.max_clients {
-                    if this.state.stats.active_clients() >= max {
+                    if this.state.stats.specific.active_clients() >= max {
                         warn!("Max connections reached ({}), rejecting incoming connection", max);
                         continue;
                     }
@@ -120,7 +120,7 @@ where
 
                 // Increment the active clients counter. If the authentication fails,
                 // this counter will be decremented.
-                this.state.stats.increment_active_clients();
+                this.state.stats.specific.increment_active_clients();
 
                 this.conn_tasks.push(accept);
 

--- a/msg-socket/src/pub/mod.rs
+++ b/msg-socket/src/pub/mod.rs
@@ -11,7 +11,8 @@ mod socket;
 pub use socket::*;
 
 mod stats;
-use stats::SocketStats;
+use crate::stats::SocketStats;
+use stats::PubStats;
 
 mod trie;
 
@@ -167,7 +168,7 @@ impl PubMessage {
 /// The publisher socket state, shared between the backend task and the socket.
 #[derive(Debug, Default)]
 pub(crate) struct SocketState {
-    pub(crate) stats: SocketStats,
+    pub(crate) stats: SocketStats<PubStats>,
 }
 
 #[cfg(test)]

--- a/msg-socket/src/pub/session.rs
+++ b/msg-socket/src/pub/session.rs
@@ -96,7 +96,7 @@ impl<Io: AsyncRead + AsyncWrite + Unpin> SubscriberSession<Io> {
 
 impl<Io> Drop for SubscriberSession<Io> {
     fn drop(&mut self) {
-        self.state.stats.decrement_active_clients();
+        self.state.stats.specific.decrement_active_clients();
     }
 }
 
@@ -157,7 +157,7 @@ impl<Io: AsyncRead + AsyncWrite + Unpin> Future for SubscriberSession<Io> {
 
                     match this.conn.start_send_unpin(msg) {
                         Ok(_) => {
-                            this.state.stats.increment_tx(msg_len);
+                            this.state.stats.specific.increment_tx(msg_len);
 
                             this.should_flush = true;
                             // We might be able to send more queued messages

--- a/msg-socket/src/pub/socket.rs
+++ b/msg-socket/src/pub/socket.rs
@@ -9,14 +9,14 @@ use tokio::{
 };
 use tracing::{debug, trace, warn};
 
-use super::{driver::PubDriver, stats::SocketStats, PubError, PubMessage, PubOptions, SocketState};
+use super::{driver::PubDriver, stats::PubStats, PubError, PubMessage, PubOptions, SocketState};
 use crate::Authenticator;
 
 use msg_transport::{Address, Transport};
 use msg_wire::compression::Compressor;
 
 /// A publisher socket. This is thread-safe and can be cloned.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct PubSocket<T: Transport<A>, A: Address> {
     /// The reply socket options, shared with the driver.
     options: Arc<PubOptions>,
@@ -190,8 +190,8 @@ where
         Ok(())
     }
 
-    pub fn stats(&self) -> &SocketStats {
-        &self.state.stats
+    pub fn stats(&self) -> &PubStats {
+        &self.state.stats.specific
     }
 
     /// Returns the local address this socket is bound to. `None` if the socket is not bound.

--- a/msg-socket/src/pub/stats.rs
+++ b/msg-socket/src/pub/stats.rs
@@ -1,16 +1,24 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Statistics for a reply socket. These are shared between the driver task
-/// and the socket.
 #[derive(Debug, Default)]
-pub struct SocketStats {
+pub struct PubStats {
     /// Total bytes sent
     bytes_tx: AtomicUsize,
     /// Total number of active request clients
     active_clients: AtomicUsize,
 }
 
-impl SocketStats {
+impl PubStats {
+    #[inline]
+    pub fn bytes_tx(&self) -> usize {
+        self.bytes_tx.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn active_clients(&self) -> usize {
+        self.active_clients.load(Ordering::Relaxed)
+    }
+
     #[inline]
     pub(crate) fn increment_tx(&self, bytes: usize) {
         self.bytes_tx.fetch_add(bytes, Ordering::Relaxed);
@@ -24,15 +32,5 @@ impl SocketStats {
     #[inline]
     pub(crate) fn decrement_active_clients(&self) {
         self.active_clients.fetch_sub(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub fn bytes_tx(&self) -> usize {
-        self.bytes_tx.load(Ordering::Relaxed)
-    }
-
-    #[inline]
-    pub fn active_clients(&self) -> usize {
-        self.active_clients.load(Ordering::Relaxed)
     }
 }

--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -6,8 +6,9 @@ use tokio::sync::oneshot;
 mod driver;
 mod socket;
 mod stats;
+use crate::stats::SocketStats;
 pub use socket::*;
-use stats::SocketStats;
+use stats::RepStats;
 
 /// Errors that can occur when using a reply socket.
 #[derive(Debug, Error)]
@@ -55,7 +56,7 @@ impl RepOptions {
 /// The request socket state, shared between the backend task and the socket.
 #[derive(Debug, Default)]
 pub(crate) struct SocketState {
-    pub(crate) stats: SocketStats,
+    pub(crate) stats: SocketStats<RepStats>,
 }
 
 /// A request received by the socket.

--- a/msg-socket/src/rep/socket.rs
+++ b/msg-socket/src/rep/socket.rs
@@ -16,15 +16,16 @@ use tokio_stream::StreamMap;
 use tracing::{debug, warn};
 
 use crate::{
-    rep::{driver::RepDriver, RepError, SocketState, SocketStats},
+    rep::{driver::RepDriver, RepError, SocketState},
     Authenticator, RepOptions, Request, DEFAULT_BUFFER_SIZE,
 };
 
 use msg_transport::{Address, Transport};
 use msg_wire::compression::Compressor;
 
+use super::stats::RepStats;
+
 /// A reply socket. This socket implements [`Stream`] and yields incoming [`Request`]s.
-#[derive(Default)]
 pub struct RepSocket<T: Transport<A>, A: Address> {
     /// The reply socket options, shared with the driver.
     options: Arc<RepOptions>,
@@ -143,8 +144,8 @@ where
     }
 
     /// Returns the statistics for this socket.
-    pub fn stats(&self) -> &SocketStats {
-        &self.state.stats
+    pub fn stats(&self) -> &RepStats {
+        &self.state.stats.specific
     }
 
     /// Returns the local address this socket is bound to. `None` if the socket is not bound.

--- a/msg-socket/src/rep/stats.rs
+++ b/msg-socket/src/rep/stats.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// Statistics for a reply socket.
 /// These are shared between the driver task and the socket.
 #[derive(Debug, Default)]
-pub struct SocketStats {
+pub struct RepStats {
     /// Total bytes sent
     bytes_tx: AtomicUsize,
     /// Total bytes received
@@ -14,7 +14,7 @@ pub struct SocketStats {
     failed_requests: AtomicUsize,
 }
 
-impl SocketStats {
+impl RepStats {
     #[inline]
     pub(crate) fn increment_tx(&self, bytes: usize) {
         self.bytes_tx.fetch_add(bytes, Ordering::Relaxed);

--- a/msg-socket/src/req/driver.rs
+++ b/msg-socket/src/req/driver.rs
@@ -156,8 +156,8 @@ where
             let _ = pending.sender.send(Ok(payload));
 
             // Update stats
-            self.socket_state.stats.update_rtt(rtt);
-            self.socket_state.stats.increment_rx(size);
+            self.socket_state.stats.specific.update_rtt(rtt);
+            self.socket_state.stats.specific.increment_rx(size);
         }
     }
 
@@ -346,7 +346,7 @@ where
                     debug!("Sending msg {}", msg.id());
                     match channel.start_send_unpin(msg) {
                         Ok(_) => {
-                            this.socket_state.stats.increment_tx(size);
+                            this.socket_state.stats.specific.increment_tx(size);
                             this.should_flush = true;
                         }
                         Err(e) => {

--- a/msg-socket/src/req/mod.rs
+++ b/msg-socket/src/req/mod.rs
@@ -11,10 +11,10 @@ use msg_wire::{
 mod driver;
 mod socket;
 mod stats;
-use driver::*;
 pub use socket::*;
 
-use self::stats::SocketStats;
+use crate::stats::SocketStats;
+use stats::ReqStats;
 
 /// The default buffer size for the socket.
 const DEFAULT_BUFFER_SIZE: usize = 1024;
@@ -182,5 +182,5 @@ impl ReqMessage {
 /// The request socket state, shared between the backend task and the socket.
 #[derive(Debug, Default)]
 pub(crate) struct SocketState {
-    pub(crate) stats: SocketStats,
+    pub(crate) stats: SocketStats<ReqStats>,
 }

--- a/msg-socket/src/req/socket.rs
+++ b/msg-socket/src/req/socket.rs
@@ -9,9 +9,9 @@ use tokio::{
 use msg_transport::{Address, Transport};
 use msg_wire::compression::Compressor;
 
-use super::{Command, ReqDriver, ReqError, ReqOptions, DEFAULT_BUFFER_SIZE};
+use super::{Command, ReqError, ReqOptions, DEFAULT_BUFFER_SIZE};
 use crate::{
-    req::{stats::SocketStats, SocketState},
+    req::{driver::ReqDriver, stats::ReqStats, SocketState},
     ConnectionState, ExponentialBackoff, ReqMessage,
 };
 
@@ -82,8 +82,8 @@ where
         self
     }
 
-    pub fn stats(&self) -> &SocketStats {
-        &self.state.stats
+    pub fn stats(&self) -> &ReqStats {
+        &self.state.stats.specific
     }
 
     pub async fn request(&self, message: Bytes) -> Result<Bytes, ReqError> {

--- a/msg-socket/src/req/stats.rs
+++ b/msg-socket/src/req/stats.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// Statistics for a request socket. These are shared between the backend task
 /// and the socket.
 #[derive(Debug, Default)]
-pub struct SocketStats {
+pub struct ReqStats {
     /// Total bytes sent
     bytes_tx: AtomicUsize,
     /// Total bytes received
@@ -14,7 +14,7 @@ pub struct SocketStats {
     rtt_idx: AtomicUsize,
 }
 
-impl SocketStats {
+impl ReqStats {
     #[inline]
     /// Atomically updates the RTT according to the CA formula:
     /// CA = (rtt + n * prev_ca) / (n + 1)

--- a/msg-socket/src/stats.rs
+++ b/msg-socket/src/stats.rs
@@ -1,34 +1,15 @@
 use std::fmt::Debug;
 
-/// A unified, generic structure to hold statistics for different socket types.
-///
-/// It contains fields common to multiple socket types (if any identified later)
-/// and a specific stats struct `S` tailored to the particular socket implementation
-/// (e.g., `SubStats`, `PubStats`).
 #[derive(Debug)]
 pub struct SocketStats<S> {
-    // --- Common fields ---
-    // We'll leave this empty for now. We can add common fields like
-    // bytes_tx, bytes_rx later if a clear pattern emerges across Pub/Sub/Rep/Req.
-    // pub(crate) bytes_tx: AtomicUsize,
-    // pub(crate) bytes_rx: AtomicUsize,
-
-    // --- Specific fields ---
-    /// Holds the statistics specific to the socket type `S`.
     pub(crate) specific: S,
 }
 
 impl<S: Default> Default for SocketStats<S> {
     fn default() -> Self {
         Self {
-            // common fields initialized here if added later...
             specific: S::default(),
         }
     }
 }
 
-// We can potentially add methods here later to access common fields if they exist.
-// impl<S> SocketStats<S> {
-//     pub fn bytes_tx(&self) -> usize { self.bytes_tx.load(Ordering::Relaxed) }
-//     pub fn bytes_rx(&self) -> usize { self.bytes_rx.load(Ordering::Relaxed) }
-// }

--- a/msg-socket/src/stats.rs
+++ b/msg-socket/src/stats.rs
@@ -1,0 +1,34 @@
+use std::fmt::Debug;
+
+/// A unified, generic structure to hold statistics for different socket types.
+///
+/// It contains fields common to multiple socket types (if any identified later)
+/// and a specific stats struct `S` tailored to the particular socket implementation
+/// (e.g., `SubStats`, `PubStats`).
+#[derive(Debug)]
+pub struct SocketStats<S> {
+    // --- Common fields ---
+    // We'll leave this empty for now. We can add common fields like
+    // bytes_tx, bytes_rx later if a clear pattern emerges across Pub/Sub/Rep/Req.
+    // pub(crate) bytes_tx: AtomicUsize,
+    // pub(crate) bytes_rx: AtomicUsize,
+
+    // --- Specific fields ---
+    /// Holds the statistics specific to the socket type `S`.
+    pub(crate) specific: S,
+}
+
+impl<S: Default> Default for SocketStats<S> {
+    fn default() -> Self {
+        Self {
+            // common fields initialized here if added later...
+            specific: S::default(),
+        }
+    }
+}
+
+// We can potentially add methods here later to access common fields if they exist.
+// impl<S> SocketStats<S> {
+//     pub fn bytes_tx(&self) -> usize { self.bytes_tx.load(Ordering::Relaxed) }
+//     pub fn bytes_rx(&self) -> usize { self.bytes_rx.load(Ordering::Relaxed) }
+// }

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -12,7 +12,7 @@ mod socket;
 pub use socket::*;
 
 mod stats;
-use stats::SocketStats;
+use stats::{SocketStats, SocketWideStats};
 
 mod stream;
 
@@ -159,11 +159,12 @@ impl<A: Address> PubMessage<A> {
 #[derive(Debug, Default)]
 pub(crate) struct SocketState<A: Address> {
     pub(crate) stats: SocketStats<A>,
+    pub(crate) socket_stats: SocketWideStats,
 }
 
 impl<A: Address> SocketState<A> {
     pub fn new() -> Self {
-        Self { stats: SocketStats::new() }
+        Self { stats: SocketStats::new(), socket_stats: SocketWideStats::default() }
     }
 }
 

--- a/msg-socket/src/sub/mod.rs
+++ b/msg-socket/src/sub/mod.rs
@@ -12,7 +12,9 @@ mod socket;
 pub use socket::*;
 
 mod stats;
-use stats::{SocketStats, SocketWideStats};
+
+use crate::stats::SocketStats;
+use stats::SubStats;
 
 mod stream;
 
@@ -155,16 +157,15 @@ impl<A: Address> PubMessage<A> {
     }
 }
 
-/// The request socket state, shared between the backend task and the socket.
-#[derive(Debug, Default)]
+/// The subscriber socket state, shared between the backend task and the socket frontend.
+#[derive(Debug)] // Should derive default fine now
 pub(crate) struct SocketState<A: Address> {
-    pub(crate) stats: SocketStats<A>,
-    pub(crate) socket_stats: SocketWideStats,
+    pub(crate) stats: SocketStats<SubStats<A>>,
 }
 
-impl<A: Address> SocketState<A> {
-    pub fn new() -> Self {
-        Self { stats: SocketStats::new(), socket_stats: SocketWideStats::default() }
+impl<A: Address> Default for SocketState<A> {
+    fn default() -> Self {
+        Self { stats: SocketStats::default() }
     }
 }
 

--- a/msg-socket/src/sub/socket.rs
+++ b/msg-socket/src/sub/socket.rs
@@ -17,9 +17,19 @@ use tokio::{
 use msg_common::JoinMap;
 use msg_transport::{Address, Transport};
 
+// ADDED: Import the specific SubStats struct for the API
+use super::stats::SubStats;
+// Import the rest from the parent module (sub/mod.rs)
 use super::{
-    Command, PubMessage, SocketState, SocketStats, SocketWideStats, SubDriver, SubError,
-    SubOptions, DEFAULT_BUFFER_SIZE,
+    // REMOVED: Old/removed stats structs
+    // Command, PubMessage, SocketState, SocketStats, SocketWideStats, SubDriver, SubError,
+    Command,
+    PubMessage,
+    SocketState,
+    SubDriver,
+    SubError,
+    SubOptions,
+    DEFAULT_BUFFER_SIZE,
 };
 
 /// A subscriber socket. This socket implements [`Stream`] and yields incoming [`PubMessage`]s.
@@ -33,7 +43,7 @@ pub struct SubSocket<T: Transport<A>, A: Address> {
     options: Arc<SubOptions>,
     /// The pending driver.
     driver: Option<SubDriver<T, A>>,
-    /// Socket state. This is shared with the socket frontend.
+    /// Socket state. This is shared with the socket frontend. Contains the unified stats.
     state: Arc<SocketState<A>>,
     /// Marker for the transport type.
     _marker: std::marker::PhantomData<T>,
@@ -132,7 +142,7 @@ where
 
         let options = Arc::new(options);
 
-        let state = Arc::new(SocketState::new());
+        let state = Arc::new(SocketState::default()); // SocketState uses default
 
         let mut publishers = FxHashMap::default();
         publishers.reserve(32);
@@ -269,12 +279,9 @@ where
         }
     }
 
-    pub fn stats(&self) -> &SocketStats<A> {
-        &self.state.stats
-    }
-
-    pub fn socket_stats(&self) -> &SocketWideStats {
-        &self.state.socket_stats
+    /// Returns the statistics specific to the subscriber socket.
+    pub fn stats(&self) -> &SubStats<A> {
+        &self.state.stats.specific
     }
 }
 

--- a/msg-socket/src/sub/socket.rs
+++ b/msg-socket/src/sub/socket.rs
@@ -18,8 +18,8 @@ use msg_common::JoinMap;
 use msg_transport::{Address, Transport};
 
 use super::{
-    Command, PubMessage, SocketState, SocketStats, SubDriver, SubError, SubOptions,
-    DEFAULT_BUFFER_SIZE,
+    Command, PubMessage, SocketState, SocketStats, SocketWideStats, SubDriver, SubError,
+    SubOptions, DEFAULT_BUFFER_SIZE,
 };
 
 /// A subscriber socket. This socket implements [`Stream`] and yields incoming [`PubMessage`]s.
@@ -271,6 +271,10 @@ where
 
     pub fn stats(&self) -> &SocketStats<A> {
         &self.state.stats
+    }
+
+    pub fn socket_stats(&self) -> &SocketWideStats {
+        &self.state.socket_stats
     }
 }
 

--- a/msg-socket/src/sub/stats.rs
+++ b/msg-socket/src/sub/stats.rs
@@ -9,40 +9,91 @@ use std::{
 use msg_transport::Address;
 use parking_lot::RwLock;
 
-/// Statistics for a reply socket. These are shared between the driver task
-/// and the socket.
-#[derive(Debug, Default)]
-pub struct SocketStats<A: Address> {
-    /// Individual session stats for each publisher
+#[derive(Debug)]
+pub struct SubStats<A: Address> {
+    /// Individual session stats for each publisher, keyed by Address.
     session_stats: RwLock<HashMap<A, Arc<SessionStats>>>,
+    /// Total number of messages dropped due to full ingress buffer between the driver and the
+    /// socket frontend.
+    dropped_messages_total: AtomicUsize,
+    /// Total number of messages successfully received by the socket frontend from the driver.
+    messages_received_total: AtomicUsize,
+    /// Total number of commands received from the socket frontend by the driver (eg. Subscribe,
+    /// Connect).
+    commands_received_total: AtomicUsize,
 }
 
-impl<A: Address> SocketStats<A> {
+impl<A: Address> Default for SubStats<A> {
+    fn default() -> Self {
+        Self {
+            session_stats: RwLock::new(HashMap::new()),
+            dropped_messages_total: AtomicUsize::new(0),
+            messages_received_total: AtomicUsize::new(0),
+            commands_received_total: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl<A: Address> SubStats<A> {
     pub fn new() -> Self {
-        Self { session_stats: RwLock::new(HashMap::new()) }
-    }
-}
-
-impl<A: Address> SocketStats<A> {
-    #[inline]
-    pub(crate) fn insert(&self, addr: A, stats: Arc<SessionStats>) {
-        self.session_stats.write().insert(addr, stats);
+        Self::default()
     }
 
-    #[inline]
-    pub(crate) fn remove(&self, addr: &A) {
-        self.session_stats.write().remove(addr);
+    /// Returns the total number of messages dropped due to the ingress buffer being full.
+    pub fn dropped_messages_total(&self) -> usize {
+        self.dropped_messages_total.load(Ordering::Relaxed)
     }
 
+    /// Returns the total number of messages successfully received by the socket frontend.
+    pub fn messages_received_total(&self) -> usize {
+        self.messages_received_total.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total number of commands processed by the socket driver.
+    pub fn commands_received_total(&self) -> usize {
+        self.commands_received_total.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total bytes received for a specific publisher session, if tracked.
     #[inline]
-    pub fn bytes_rx(&self, session_addr: &A) -> Option<usize> {
+    pub fn session_bytes_rx(&self, session_addr: &A) -> Option<usize> {
         self.session_stats.read().get(session_addr).map(|stats| stats.bytes_rx())
     }
 
-    /// Returns the average latency in microseconds for the given session.
+    /// Returns the average latency in microseconds for a specific publisher session, if tracked.
     #[inline]
-    pub fn avg_latency(&self, session_addr: &A) -> Option<u64> {
+    pub fn session_avg_latency(&self, session_addr: &A) -> Option<u64> {
         self.session_stats.read().get(session_addr).map(|stats| stats.avg_latency())
+    }
+
+    /// Inserts stats for a new publisher session. (Used by SubDriver)
+    #[inline]
+    pub(crate) fn insert_session(&self, addr: A, stats: Arc<SessionStats>) {
+        self.session_stats.write().insert(addr, stats);
+    }
+
+    /// Removes stats for a publisher session. (Used by SubDriver)
+    #[inline]
+    pub(crate) fn remove_session(&self, addr: &A) {
+        self.session_stats.write().remove(addr);
+    }
+
+    /// Increments the dropped messages counter. (Used by SubDriver)
+    #[inline]
+    pub(crate) fn increment_dropped_messages(&self) {
+        self.dropped_messages_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increments the received messages counter. (Used by SubDriver)
+    #[inline]
+    pub(crate) fn increment_messages_received(&self) {
+        self.messages_received_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increments the received commands counter. (Used by SubDriver)
+    #[inline]
+    pub(crate) fn increment_commands_received(&self) {
+        self.commands_received_total.fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -82,44 +133,5 @@ impl SessionStats {
     #[inline]
     pub fn avg_latency(&self) -> u64 {
         self.latency.load(Ordering::Relaxed)
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct SocketWideStats {
-    /// Total number of messages dropped due to full ingress buffer between the driver and the
-    /// socket frontend.
-    dropped_messages_total: AtomicUsize,
-    /// Total number of messages successfully received by the socket frontend from the driver.
-    messages_received_total: AtomicUsize,
-    /// Total number of commands received from the socket frontend by the driver (eg. Subscribe,
-    /// Connect)
-    commands_received_total: AtomicUsize,
-}
-
-impl SocketWideStats {
-    /// Returns the total number of messages dropped due to the ingress buffer being full.
-    pub fn dropped_messages_total(&self) -> usize {
-        self.dropped_messages_total.load(Ordering::Relaxed)
-    }
-
-    /// Returns the total number of messages successfully received by the socket frontend.
-    pub fn messages_received_total(&self) -> usize {
-        self.messages_received_total.load(Ordering::Relaxed)
-    }
-
-    /// Returns the total number of commands processed by the socket driver.
-    pub fn commands_received_total(&self) -> usize {
-        self.commands_received_total.load(Ordering::Relaxed)
-    }
-
-    /// Increments the dropped messages counter. (Used by SubDriver)
-    pub(crate) fn increment_dropped_messages(&self) {
-        self.dropped_messages_total.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Increments the received messages counter. (Used by SubDriver)
-    pub(crate) fn increment_messages_received(&self) {
-        self.messages_received_total.fetch_add(1, Ordering::Relaxed);
     }
 }

--- a/msg-socket/src/sub/stats.rs
+++ b/msg-socket/src/sub/stats.rs
@@ -84,3 +84,42 @@ impl SessionStats {
         self.latency.load(Ordering::Relaxed)
     }
 }
+
+#[derive(Debug, Default)]
+pub struct SocketWideStats {
+    /// Total number of messages dropped due to full ingress buffer between the driver and the
+    /// socket frontend.
+    dropped_messages_total: AtomicUsize,
+    /// Total number of messages successfully received by the socket frontend from the driver.
+    messages_received_total: AtomicUsize,
+    /// Total number of commands received from the socket frontend by the driver (eg. Subscribe,
+    /// Connect)
+    commands_received_total: AtomicUsize,
+}
+
+impl SocketWideStats {
+    /// Returns the total number of messages dropped due to the ingress buffer being full.
+    pub fn dropped_messages_total(&self) -> usize {
+        self.dropped_messages_total.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total number of messages successfully received by the socket frontend.
+    pub fn messages_received_total(&self) -> usize {
+        self.messages_received_total.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total number of commands processed by the socket driver.
+    pub fn commands_received_total(&self) -> usize {
+        self.commands_received_total.load(Ordering::Relaxed)
+    }
+
+    /// Increments the dropped messages counter. (Used by SubDriver)
+    pub(crate) fn increment_dropped_messages(&self) {
+        self.dropped_messages_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increments the received messages counter. (Used by SubDriver)
+    pub(crate) fn increment_messages_received(&self) {
+        self.messages_received_total.fetch_add(1, Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
Implement statistics tracking for the SubSocket, #37  

Add a new `SocketWideStats` struct to hold metrics related to
the overall socket operation, distinct from per-publisher stats. Includes counters for:
- Messages dropped due to a full ingress buffer (driver -> socket)
- Messages successfully received by the socket frontend from the driver