### PR TITLE
IPv6 support

### DIFF
--- a/msg-common/src/lib.rs
+++ b/msg-common/src/lib.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use std::{
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     time::SystemTime,
 };
 
@@ -45,24 +45,38 @@ pub trait SocketAddrExt: Sized {
     /// Returns the unspecified IPv6 socket address, bound to port 0.
     fn unspecified_v6() -> Self;
 
-    /// Returns the unspecified socket address bound to port 0 of the same protocol version of
-    /// the provided address.
-    fn unspecified_compatible_with(other: &Self) -> Self;
+    /// Returns the unspecified socket address of the same family as `other`, bound to port 0.
+    fn as_unspecified(&self) -> Self;
 }
 
 impl SocketAddrExt for SocketAddr {
     fn unspecified_v4() -> Self {
-        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
+        Self::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
     }
 
     fn unspecified_v6() -> Self {
-        SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0))
+        Self::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0))
     }
 
-    fn unspecified_compatible_with(other: &Self) -> Self {
-        match other {
-            SocketAddr::V4(_) => Self::unspecified_v4(),
-            SocketAddr::V6(_) => Self::unspecified_v6(),
+    fn as_unspecified(&self) -> Self {
+        match self {
+            Self::V4(_) => Self::unspecified_v4(),
+            Self::V6(_) => Self::unspecified_v6(),
+        }
+    }
+}
+
+/// Extension trait for IP addresses.
+pub trait IpAddrExt: Sized {
+    /// Returns the localhost address of the same family as `other`.
+    fn as_localhost(&self) -> Self;
+}
+
+impl IpAddrExt for IpAddr {
+    fn as_localhost(&self) -> Self {
+        match self {
+            Self::V4(_) => Self::V4(Ipv4Addr::LOCALHOST),
+            Self::V6(_) => Self::V6(Ipv6Addr::LOCALHOST),
         }
     }
 }

--- a/msg-socket/src/sub/socket.rs
+++ b/msg-socket/src/sub/socket.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashSet,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::SocketAddr,
     path::PathBuf,
     pin::Pin,
     sync::Arc,
@@ -14,7 +14,7 @@ use tokio::{
     sync::mpsc,
 };
 
-use msg_common::JoinMap;
+use msg_common::{IpAddrExt, JoinMap};
 use msg_transport::{Address, Transport};
 
 // ADDED: Import the specific SubStats struct for the API
@@ -61,11 +61,7 @@ where
         // Some transport implementations (e.g. Quinn) can't dial an unspecified
         // IP address, so replace it with localhost.
         if endpoint.ip().is_unspecified() {
-            let localhost = match endpoint.ip() {
-                IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::LOCALHOST),
-                IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
-            };
-            endpoint.set_ip(localhost);
+            endpoint.set_ip(endpoint.ip().as_localhost());
         }
 
         self.connect_inner(endpoint).await
@@ -79,11 +75,7 @@ where
         // Some transport implementations (e.g. Quinn) can't dial an unspecified
         // IP address, so replace it with localhost.
         if endpoint.ip().is_unspecified() {
-            let localhost = match endpoint.ip() {
-                IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::LOCALHOST),
-                IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
-            };
-            endpoint.set_ip(localhost);
+            endpoint.set_ip(endpoint.ip().as_localhost());
         }
 
         self.try_connect_inner(endpoint)

--- a/msg-transport/src/quic/mod.rs
+++ b/msg-transport/src/quic/mod.rs
@@ -113,8 +113,7 @@ impl Transport<SocketAddr> for Quic {
         let endpoint = if let Some(endpoint) = self.endpoint.clone() {
             endpoint
         } else {
-            let endpoint_addr = SocketAddr::unspecified_compatible_with(&addr);
-            let Ok(mut endpoint) = self.new_endpoint(endpoint_addr, None) else {
+            let Ok(mut endpoint) = self.new_endpoint(addr.as_unspecified(), None) else {
                 return async_error(Error::ClosedEndpoint);
             };
 


### PR DESCRIPTION
Tried to give a stab at #63.

To me it seemed that there wasn't much to change, except a couple of tweaks to be aware of whether we're using IPv6 or not. To test it, I've added a commit (to be dropped after approval of the changes) where I replace all `127.0.0.1` and `0.0.0.0` occurrences in both tests and benches, and they run fine.

To avoid clutter in reading the PR, it can be read commit by commit.