### PR TITLE
feat(socket): expose sync method to start connecting

### DIFF
--- a/msg-socket/src/req/driver.rs
+++ b/msg-socket/src/req/driver.rs
@@ -31,7 +31,7 @@ use msg_wire::{
 type ConnectionTask<Io, Err> = Pin<Box<dyn Future<Output = Result<Io, Err>> + Send>>;
 
 /// A connection controller that manages the connection to a server with an exponential backoff.
-type ConnectionCtl<Io, S, A> =
+pub(crate) type ConnectionCtl<Io, S, A> =
     ConnectionState<Framed<MeteredIo<Io, S, A>, reqrep::Codec>, ExponentialBackoff, A>;
 
 /// The request socket driver. Endless future that drives


### PR DESCRIPTION
Exposes a connection method on the `ReqSocket` that doesn't error nor blocks, so it can be used in synchronous contexts without worries.

There is a TODO left that is recycled from current implementation, and should be addressed properly with #97.