### PR TITLE
chore: bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "msg"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "criterion",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "msg-common"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "derive_more",
  "futures",
@@ -862,14 +862,14 @@ dependencies = [
 
 [[package]]
 name = "msg-sim"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "pnet",
 ]
 
 [[package]]
 name = "msg-socket"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "msg-transport"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "msg-wire"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
We have a `v0.1.4` tag but we forgot to bump the cargo version, breaking CI.