### PR TITLE
fix(socket/rep): demote logs from potential spamming peer

### DIFF
--- a/msg-socket/src/rep/mod.rs
+++ b/msg-socket/src/rep/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{io, time::Duration};
 
 use bytes::Bytes;
 use msg_common::constants::KiB;
@@ -28,6 +28,17 @@ pub enum RepError {
     SocketClosed,
     #[error("Could not connect to any valid endpoints")]
     NoValidEndpoints,
+}
+
+impl RepError {
+    pub fn is_connection_reset(&self) -> bool {
+        match self {
+            Self::Io(e) | Self::Wire(msg_wire::reqrep::Error::Io(e)) => {
+                e.kind() == io::ErrorKind::ConnectionReset
+            }
+            _ => false,
+        }
+    }
 }
 
 /// The reply socket options.


### PR DESCRIPTION
We should be wary of INFO/WARN/ERROR level logs in the codebase that could be triggered by a malicious peer, and can result in noise or filling up storage on production services. The PR is a first step in this direction