### PR TITLE
chore: bump version v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "msg"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bytes",
  "criterion",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "msg-common"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "derive_more",
  "futures",
@@ -938,14 +938,14 @@ dependencies = [
 
 [[package]]
 name = "msg-sim"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "pnet",
 ]
 
 [[package]]
 name = "msg-socket"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "msg-transport"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "msg-wire"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
We cut a new version with #147 and #143 which would be needed for FlowProxy.