### PR TITLE
fix: update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
-version = "1.88.0"
+channel = "1.88.0"
+components = ["rust-analyzer"]


### PR DESCRIPTION
The `version` field doesn't really exist, my bad. Reference: https://rust-lang.github.io/rustup/overrides.html#toolchain-file-settings.

Also worth to explicitly add to install `rust-analyzer` of the correct version and not leave your IDE of choice to whatever stable version has installed. 