### PR TITLE
fix: docs build, CI for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,9 @@ jobs:
           cache-on-failure: true
 
       - name: Check documentation
-        run: RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all --no-deps --all-features --document-private-items
+        run: cargo +nightly doc --all --no-deps --all-features --document-private-items
         env:
-          RUSTDOCFLAGS: "-D warnings"
+          RUSTDOCFLAGS: "-D warnings --cfg docsrs"
 
   # Find unused dependencies, this will fail if any are found.
   cargo-shear:

--- a/msg-common/src/lib.rs
+++ b/msg-common/src/lib.rs
@@ -1,7 +1,7 @@
 //! Common utilities and types for msg-rs.
 
 #![doc(issue_tracker_base_url = "https://github.com/chainbound/msg-rs/issues/")]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use std::{

--- a/msg-sim/Cargo.toml
+++ b/msg-sim/Cargo.toml
@@ -11,6 +11,9 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
+
 [dependencies]
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/msg-sim/src/lib.rs
+++ b/msg-sim/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(issue_tracker_base_url = "https://github.com/chainbound/msg-rs/issues/")]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! In-process network emulation for Linux, powered by `rtnetlink`.
 

--- a/msg-socket/src/lib.rs
+++ b/msg-socket/src/lib.rs
@@ -8,7 +8,7 @@
 //! Sockets are the main entrypoint in this library and facilitate all connectivity, like binding or
 //! connecting, and sending and receiving messages over connections.
 #![doc(issue_tracker_base_url = "https://github.com/chainbound/msg-rs/issues/")]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod stats;

--- a/msg-transport/src/lib.rs
+++ b/msg-transport/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(issue_tracker_base_url = "https://github.com/chainbound/msg-rs/issues/")]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use std::{

--- a/msg-wire/src/lib.rs
+++ b/msg-wire/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(issue_tracker_base_url = "https://github.com/chainbound/msg-rs/issues/")]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod auth;

--- a/msg/src/lib.rs
+++ b/msg/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(issue_tracker_base_url = "https://github.com/chainbound/msg-rs/issues/")]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use msg_socket::*;
 pub use msg_transport::*;


### PR DESCRIPTION
- The `doc_auto_cfg` feature was https://github.com/rust-lang/rust/pull/138907 and merged into `doc_cfg`. Since `docs.rs` uses nightly Rust (which is past 1.92.0), `feature(doc_cfg, doc_auto_cfg)` causes a hard compilation error.
- Added `--cfg docsrs` to `RUSTDOCFLAGS` so CI now mirrors the `docs.rs` build environment and would catch issues like the `doc_auto_cfg` removal
