### PR TITLE
Fix: Mdbook build due to deprecated options & extension

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,14 +1,11 @@
 [book]
 authors = ["Nicolas Racchi"]
 language = "en"
-multilingual = false
 src = "src"
 title = "The MSG-RS Book"
 
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
-
-[preprocessor.template]
 
 [output.html]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]


### PR DESCRIPTION
Take a look at this [issue](https://github.com/chainbound/msg-rs/issues/182) to learn more.

- [mdbook-template](https://github.com/sgoudham/mdbook-template) is deprecated and we don't currently use it.
- We no longer need `multilingual = false` in mbook >= 0.5.0 removed by https://github.com/rust-lang/mdBook/pull/2775
